### PR TITLE
Adding a simple Travis matrix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,14 @@ services:
   - docker
 
 env:
-  DOCKER_COMPOSE_VERSION: 1.6.0
-  CUSTOM_NETWORK_NAME: local_network
-  TARGET_HOST: localhost
+  global:
+    - DOCKER_COMPOSE_VERSION=1.6.0
+    - CUSTOM_NETWORK_NAME=local_network
+    - TARGET_HOST=localhost
+    - LOGSTASH_HOST=localhost
+  matrix:
+    - DOCKER_COMPOSE_TOOLS="-f docker-compose.yml" DOCKER_COMPOSE_VOLUMES="-f etc/volumes/local/default.yml" DOCKER_COMPOSE_LOGGING=""
+    - DOCKER_COMPOSE_TOOLS="-f docker-compose.yml" DOCKER_COMPOSE_VOLUMES="-f etc/volumes/local/default.yml" DOCKER_COMPOSE_LOGGING="-f etc/logging/syslog/default.yml"
 
 before_install:
  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
@@ -16,10 +21,11 @@ before_install:
  
 before_script:
   - docker network create ${CUSTOM_NETWORK_NAME}
+  - docker-compose -f compose/elk.yml up -d
   - docker-compose pull
 
 script:
   - source env.config.sh
-  - docker-compose -f docker-compose.yml -f etc/volumes/local/default.yml up -d
+  - docker-compose ${DOCKER_COMPOSE_TOOLS} ${DOCKER_COMPOSE_VOLUMES} ${DOCKER_COMPOSE_LOGGING} up -d
   - docker-compose ps
   - docker ps

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: bash
+
+sudo: required
+services:
+  - docker
+
+env:
+  DOCKER_COMPOSE_VERSION: 1.6.0
+  CUSTOM_NETWORK_NAME: local_network
+  TARGET_HOST: localhost
+
+before_install:
+ - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+ - chmod +x docker-compose
+ - sudo mv docker-compose /usr/local/bin
+ 
+before_script:
+  - docker network create ${CUSTOM_NETWORK_NAME}
+  - docker-compose pull
+
+script:
+  - source env.config.sh
+  - docker-compose -f docker-compose.yml -f etc/volumes/local/default.yml up -d
+  - docker-compose ps
+  - docker ps

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/Accenture/adop-docker-compose.svg?branch=master)](https://travis-ci.org/Accenture/adop-docker-compose)
+
 # The DevOps Platform: Overview
 
 The DevOps Platform is a tools environment for continuously testing, releasing and maintaining applications. Reference code, delivery pipelines, automated testing and environments can be loaded in via the concept of Cartridges.


### PR DESCRIPTION
This adds a simple build that uses a matrix to switch on and off the use of the logging driver. It only goes as far as making sure the services can be started, it'd need extending to check that all of the services came up successfully. Also adds the build status image to the readme.