### PR TITLE
Support for getting AWS credentials from default aws credentials file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ These instructions will spin up an instance in a single server in AWS (for evalu
 1. Clone this repository and then in a terminal window (this has been tested in GitBash) run:
 ```bash
 $ ./startup.sh
-Usage: ./startup.sh -m <MACHINE_NAME> -a <AWS_ACCESS_KEY> -s <AWS_SECRET_ACCESS_KEY> -c <VPC_ID> -r <REGION> -v <VOLUME_DRIVER> -n <CUSTOM_NETWORK_NAME>(optional) -l LOGGING_DRIVER(optional) -f path/to/additional_override1.yml(optional) -f path/to/additional_override2.yml(optional) ...
+Usage: ./startup.sh -m <MACHINE_NAME> -a <AWS_ACCESS_KEY>(optional) -s <AWS_SECRET_ACCESS_KEY>(optional) -c <VPC_ID> -r <REGION> -v <VOLUME_DRIVER> -n <CUSTOM_NETWORK_NAME>(optional) -l LOGGING_DRIVER(optional) -f path/to/additional_override1.yml(optional) -f path/to/additional_override2.yml(optional) ...
 ```
 * You will need to supply:
     - a machine name (anything you want)
-    - your AWS key and your secret access key (see [getting your AWS access key](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html))
+    - your AWS key and your secret access key (see [getting your AWS access key](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html)) via command line options, environment variables or using aws configure 
     - the target VPC
     - the AWS region id in this format: eu-west-1
 For example

--- a/startup.sh
+++ b/startup.sh
@@ -14,7 +14,7 @@ echo '
 '
 
 usage(){
-	echo "Usage: ./startup.sh -m <MACHINE_NAME> -a <AWS_ACCESS_KEY> -s <AWS_SECRET_ACCESS_KEY> -c <VPC_ID> -r <REGION> -v <VOLUME_DRIVER>(optional) -n <CUSTOM_NETWORK_NAME>(optional) -l LOGGING_DRIVER(optional) -f path/to/additional_override1.yml(optional) -f path/to/additional_override2.yml(optional) ..."
+  echo "Usage: ./startup.sh -m <MACHINE_NAME> -a <AWS_ACCESS_KEY>(optional) -s <AWS_SECRET_ACCESS_KEY>(optional) -c <VPC_ID> -r <REGION> -v <VOLUME_DRIVER>(optional) -n <CUSTOM_NETWORK_NAME>(optional) -l LOGGING_DRIVER(optional) -f path/to/additional_override1.yml(optional) -f path/to/additional_override2.yml(optional) ..."
 }
 
 # Defaults
@@ -62,11 +62,15 @@ done
 
 if [ -z $MACHINE_NAME ] | \
 	[ -z $CUSTOM_NETWORK_NAME ] | \
-	[ -z $AWS_ACCESS_KEY ] | \
 	[ -z $VPC_ID ] | \
 	[ -z $REGION ]; then
   usage
   exit 1
+fi
+
+if [ -z $AWS_ACCESS_KEY ];
+then
+  echo "Using default AWS credentials from ~/.aws/credentials"
 fi
 
 source env.config.sh
@@ -75,7 +79,7 @@ source env.config.sh
 if $(docker-machine env $MACHINE_NAME > /dev/null 2>&1) ; then
 	echo "Docker machine '$MACHINE_NAME' already exists"
 else
-  docker-machine create --driver amazonec2 --amazonec2-access-key $AWS_ACCESS_KEY --amazonec2-secret-key $AWS_SECRET_ACCESS_KEY --amazonec2-vpc-id $VPC_ID --amazonec2-instance-type t2.large --amazonec2-region $REGION $MACHINE_NAME
+  docker-machine create --driver amazonec2 --amazonec2-vpc-id $VPC_ID --amazonec2-instance-type t2.large --amazonec2-region $REGION $MACHINE_NAME
 fi
 
 # Create Docker network if one doesn't already exist with the same name


### PR DESCRIPTION
Making providing startup.sh options for AWS access and secret key optional, enabling alternative commonly used ways of providing credentials:
- via command line switches (currently supported)
- via environment variables
- via aws configure
- via IAM role attached to instance running script (if docker machine supports it)

https://docs.docker.com/machine/drivers/aws/#configuring-credentials