### PR TITLE
Adding the basic CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,27 +7,12 @@ services:
 env:
   global:
     - DOCKER_COMPOSE_VERSION=1.6.0
-    - CUSTOM_NETWORK_NAME=local_network
-    - TARGET_HOST=localhost
-    - LOGSTASH_HOST=localhost
     - INITIAL_ADMIN_USER=admin.user
-  matrix:
-    - DOCKER_COMPOSE_TOOLS="-f docker-compose.yml" DOCKER_COMPOSE_VOLUMES="-f etc/volumes/local/default.yml" DOCKER_COMPOSE_LOGGING=""
-    - DOCKER_COMPOSE_TOOLS="-f docker-compose.yml" DOCKER_COMPOSE_VOLUMES="-f etc/volumes/local/default.yml" DOCKER_COMPOSE_LOGGING="-f etc/logging/syslog/default.yml"
 
 before_install:
  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
  - chmod +x docker-compose
  - sudo mv docker-compose /usr/local/bin
- 
-before_script:
-  - docker network create ${CUSTOM_NETWORK_NAME}
-  - docker-compose -f compose/elk.yml up -d
-  - docker-compose pull
 
 script:
-  - source credentials.generate.sh
-  - source env.config.sh
-  - docker-compose ${DOCKER_COMPOSE_TOOLS} ${DOCKER_COMPOSE_VOLUMES} ${DOCKER_COMPOSE_LOGGING} up -d
-  - docker-compose ps
-  - docker ps
+ - ./adop compose init

--- a/README.md
+++ b/README.md
@@ -66,6 +66,60 @@ Navigate to http://11.22.33.44 in your browser to use your new DevOps Platform!
 <INITIAL_ADMIN_USER>/ <INITIAL_ADMIN_PASSWORD_PLAIN>
 ```
 
+# Quickstart Instructions (Experimental)
+
+These instructions will spin up an instance in a single server in AWS (for evaluation purposes).
+
+1. Create a VPC using the [VPC wizard](http://docs.aws.amazon.com/AmazonVPC/latest/GettingStartedGuide/getting-started-create-vpc.html) in the AWS console by selecting the first option with 1 public subnet.
+1. On the "Step 2: VPC with a Single Public Subnet" page give your VPC a meaningful name and specify the availability zone as 'a', e.g. select eu-west-1a from the pulldown.
+1. Once the VPC is created note the VPC ID (e.g. vpc-1ed3sfgw)
+1. Clone this repository and then in a terminal window (this has been tested in GitBash):
+    - Run:
+
+        ```./quickstart.sh ```
+        ```bash
+        $ ./quickstart.sh
+        Usage: ./quickstart.sh -t aws
+                               -m <MACHINE_NAME>  
+                               -c <VPC_ID> 
+                               -r <REGION>(optional) 
+                               -z <VPC_AVAIL_ZONE>(optional)
+                               -a <AWS_ACCESS_KEY>(optional) 
+                               -s <AWS_SECRET_ACCESS_EY>(optional) 
+                               -u <ADMIN_USER>
+                               -p <PASSWORD>(optional) ...
+        ```
+        - You will need to supply:
+            - the type of machine to create (aws, in this example)
+            - a machine name (anything you want)
+            - the target VPC
+            - If you don't have your AWS credentials and default region [stored locally in ~/.aws](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files) you will also need to supply:
+                - your AWS key and your secret access key (see [getting your AWS access key](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html)) via command line options, environment variables or using aws configure 
+                - the AWS region id in this format: eu-west-1
+            - a username and password to act as credentials for the initial admin user
+    - For example (if you don't have ~/.aws set up):
+
+        ```./quickstart.sh -t aws -m adop1 -a AAA -s BBB -c vpc-123abc -r eu-west-1 -u user.name -p userPassword```
+        - N.B. If you see an error saying that docker-machine cannot find an associated subnet in a zone, go back to the VPC Dashboard on AWS and check the availablity zone for the subnet you've created. Then rerun the startup script and use the -z option to specify the zone for your subnet, e.g. for a zone of eu-west-1c the above command becomes:
+
+            ```./quickstart.sh -t aws -m adop1 -a AAA -s BBB -c vpc-123abc -r eu-west-1 -u user.name -p userPassword -z c```
+1. If all goes well you will see the following output and you can view the DevOps Platform in your browser
+    ```
+    ##########################################################
+
+    SUCCESS, your new ADOP instance is ready!
+
+    Run this command in your shell:
+        source credentials.generate.sh
+        source env.config.sh
+
+    Navigate to http://11.22.33.44 in your browser to use your new DevOps Platform!
+    ```
+1. Log in using the username and password you specified in the quickstart script:
+```
+<INITIAL_ADMIN_USER> / <INITIAL_ADMIN_PASSWORD>
+```
+
 # General Getting Started Instructions
 
 The platform is designed to run on any container platform. 

--- a/README.md
+++ b/README.md
@@ -124,23 +124,37 @@ These instructions will spin up an instance in a single server in AWS (for evalu
 
 The platform is designed to run on any container platform. 
 
-## To run in AWS (single instance) manually
+## Provision Docker Engine(s)
+
+### To run in AWS (single instance) manually
 
 - Create a VPC using the VPC wizard in the AWS console by selecting the first option with 1 public subnet
 
-- Create a Docker Engine in AWS: 
+- Create a Docker Engine in AWS (replace the placeholders and their <> markers): 
 ```sh
-docker-machine create --driver amazonec2 --amazonec2-access-key YOUR\_ACCESS\_KEY --amazonec2-secret-key YOUR\_SECRET\_KEY --amazonec2-vpc-id vpc-YOUR_ID --amazonec2-instance-type t2.large --amazonec2-region REGION IN THIS FORMAT: eu-west-1   YOUR\_MACHINE\_NAME
+docker-machine create --driver amazonec2 --amazonec2-access-key <YOUR_ACCESS_KEY> --amazonec2-secret-key <YOUR_SECRET_KEY> --amazonec2-vpc-id <YOUR_VPC_ID> --amazonec2-instance-type t2.large --amazonec2-region <YOUR_AWS_REGION, e.g. eu-west-1> <YOUR_MACHINE_NAME>
 ```
 
 - Update the docker-machine security group to permit inbound http traffic on port 80 (from the machine(s) from which you want to have access only), also UDP on 25826 and 12201 from 127.0.0.1/32
 
-- Set your local environment variables to point docker-machine to your new instance
+- Set your local environment variables to point docker-machine to your new instance:
+```sh
+eval $(docker-machine env <YOUR_MACHINE_NAME>)
+```
 
-## To run locally
-Create a docker machine and set up your local environment variables to point docker-machine to your new instance
+### To run locally
 
-## To run with Docker Swarm
+- Create a local Docker Engine (replace the placeholders and their <> markers):
+```sh
+docker-machine create --driver virtualbox --virtualbox-memory 2048 <YOUR_MACHINE_NAME>
+```
+
+- Set your local environment variables to point docker-machine to your new instance:
+```sh
+eval $(docker-machine env <YOUR_MACHINE_NAME>)
+```
+
+### To run with Docker Swarm
 
 Create a Docker Swarm that has a publicly accessible Engine with the label "tier=public" to bind Nginx and Logstash to that node
 

--- a/adop
+++ b/adop
@@ -1,0 +1,43 @@
+#!/bin/bash -e
+
+CMD_NAME=`basename "$0"`
+
+# The sed expression here replaces all backslashes by forward slashes.
+# This helps our Windows users, while not bothering our Unix users.
+export CLI_DIR=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+export CONF_DIR="${CLI_DIR}"
+CLI_CMD_DIR="${CLI_DIR}/cmd"
+
+usage() {
+    echo "usage: ${CMD_NAME} <subcommand>"
+    echo
+    echo "Available subcommands are:"
+    for command in $(ls $CLI_DIR/cmd)
+    do
+        printf "    %-10s   $(. ${CLI_CMD_DIR}/${command} cmd_desc)" "${command}"
+        echo
+    done
+    echo
+    echo "Try '${CMD_NAME} <subcommand> help' for details."
+    echo "HINT: Run '${CMD_NAME} compose init' to start the platform"
+    echo
+}
+
+main() {
+    if [ $# -lt 1 ]; then
+        usage
+        exit 1
+    fi
+
+    SUBCOMMAND="$1"; shift
+
+    if [ ! -e "${CLI_CMD_DIR}/$SUBCOMMAND" ]; then
+        usage
+        exit 1
+    fi
+
+    # run command
+    . "${CLI_CMD_DIR}/$SUBCOMMAND" "$@"
+}
+
+main "$@"

--- a/cmd/compose
+++ b/cmd/compose
@@ -1,0 +1,277 @@
+#!/bin/bash -e
+
+SUB_CMD_NAME="compose"
+
+cmd_desc() {
+    echo "For running Docker Compose related commands"
+}
+
+cmd_usage() {
+    echo "usage: ${CMD_NAME} ${SUB_CMD_NAME} [<options>] <subcommand>"
+    echo "Options:"
+    printf "    %-12s   %s\n" "-m <name>" "The name of the Docker Machine to target"
+    printf "    %-12s   %s\n" "-f <path>" "Additional override file for Docker Compose, can be specified more than once"
+    printf "    %-12s   %s\n" "-F <path>" "File to use for Docker Compose (in place of default), can be specified more than once"
+    printf "    %-12s   %s\n" "-l <driver>" "The logging driver to use"
+    printf "    %-12s   %s\n" "-v <driver>" "The volume driver to use"
+    printf "    %-12s   %s\n" "-n <name>" "The custom network to create (if not present) and use"
+    printf "    %-12s   %s\n" "-i <ip>" "The public IP that the proxy will be accessed from (only required when not using Docker Machine)"
+}
+
+help() {
+    cmd_usage
+    echo
+    echo "Available subcommands are:"
+    printf "    %-16s   %s\n" "init" "Initialises ADOP"
+    printf "    %-16s   %s\n" "up" "docker-compose up for ADOP"
+    printf "    %-16s   %s\n" "gen-certs <path>" "Generate client certificates for TLS-enabled Machine and copy to <path> in Jenkins Slave"
+    printf "    %-16s   %s\n" "<command>" "Runs 'docker-compose <command>' for ADOP, where <command> is not listed above"
+    printf "    %-16s   %s\n" "help" "Prints this help information"
+    echo
+}
+
+prep_env() {
+    # If the proxy IP has not been set work out the TARGET_HOST
+    # Else just use it
+    if [ -z "${PROXY_IP}" ]; then
+        # If MACHINE_NAME is not the default or it is and it exists
+        # Else fall back to localhost
+        if [ "${MACHINE_NAME}" != "${DEFAULT_MACHINE_NAME}" ] || ([ "${MACHINE_NAME}" = "${DEFAULT_MACHINE_NAME}" ] && $(docker-machine ip ${MACHINE_NAME} > /dev/null 2>&1) ); then
+            # Check the machine exists first
+            if ! $(docker-machine ip ${MACHINE_NAME} > /dev/null 2>&1) ; then
+               echo "The specified Docker Machine does not exist: ${MACHINE_NAME}"
+               echo "HINT: Either specify one with 'adop compose -m <name>', or use 'eval \$(docker-machine env ${MACHINE_NAME})'"
+               exit 1
+            else
+                # Set the machine
+                eval $( docker-machine env $MACHINE_NAME )
+
+                export TARGET_HOST=$(docker-machine ip $MACHINE_NAME)
+                export LOGSTASH_HOST=$(docker-machine ip $MACHINE_NAME)
+            fi
+        else
+            echo "Docker Machine is not available or the default machine does not exist, defaulting to localhost"
+            echo "HINT: Either specify one with 'adop compose -m <name>', or use 'eval \$(docker-machine env ${MACHINE_NAME})'"
+            export TARGET_HOST=localhost
+            export LOGSTASH_HOST=localhost
+        fi
+    else
+        export TARGET_HOST=${PROXY_IP}
+        export LOGSTASH_HOST=${PROXY_IP}
+    fi
+
+    source ${CONF_DIR}/credentials.generate.sh
+    source ${CONF_DIR}/env.config.sh
+}
+
+init() {
+    echo ' 
+          ###    ########   #######  ########  
+         ## ##   ##     ## ##     ## ##     ## 
+        ##   ##  ##     ## ##     ## ##     ## 
+       ##     ## ##     ## ##     ## ########  
+       ######### ##     ## ##     ## ##        
+       ##     ## ##     ## ##     ## ##        
+       ##     ## ########   #######  ##        
+    '
+
+    echo "* Initialising ADOP"
+
+    # Load variables
+    prep_env
+
+    # Create the network
+    echo "* Setting up Docker Network"
+    create_network
+
+    # Run the Docker compose commands
+    echo "* Pulling Docker Images"
+    run_compose pull
+    echo "* Bringing up ADOP..."
+    run_compose up -d
+
+    # Wait for Jenkins and Gerrit to come up before proceeding
+    echo "* Waiting for the Platform to become available - this can take a few minutes"
+    TOOL_SLEEP_TIME=60
+    until [[ $(docker exec jenkins curl -I -s jenkins:${PASSWORD_JENKINS}@localhost:8080/jenkins/|head -n 1|cut -d$' ' -f2) == 200 ]]; do echo "Jenkins unavailable, sleeping for ${TOOL_SLEEP_TIME}s"; sleep ${TOOL_SLEEP_TIME}; done
+    until [[ $(docker exec gerrit curl -I -s gerrit:${PASSWORD_GERRIT}@localhost:8080/gerrit/|head -n 1|cut -d$' ' -f2) == 200 ]]; do echo "Gerrit unavailable, sleeping for ${TOOL_SLEEP_TIME}s"; sleep ${TOOL_SLEEP_TIME}; done
+    
+    # Trigger Load_Platform in Jenkins
+    echo "* Initialising the Platform"
+    docker exec jenkins curl -s -X POST jenkins:${PASSWORD_JENKINS}@localhost:8080/jenkins/job/Load_Platform/buildWithParameters --data token=gAsuE35s
+
+    # Generate and copy the certificates to jenkins slave if TLS is enabled
+    if [ "${DOCKER_TLS_VERIFY}" = "1" ]; then
+        gen-certs "${DOCKER_CLIENT_CERT_PATH}"
+    else
+        echo "DOCKER_TLS_VERIFY not set to 1, skipping certificate generation"
+    fi
+    
+    # Tell the user something useful
+    echo
+    echo '##########################################################'
+    echo
+    echo "SUCCESS, your new ADOP instance is ready!"
+    echo
+    echo "Run this command in your shell:"
+    echo '  source env.config.sh'
+    echo '  source credentials.generate.sh'
+    echo
+    echo "You can check if any variables are missing with: ./adop compose config  | grep 'WARNING'"
+    echo
+    echo "Navigate to http://${TARGET_HOST} in your browser to use your new DevOps Platform!"
+    echo "Login using the following credentials:"
+    echo "  Username: ${INITIAL_ADMIN_USER}"
+    echo "  Password: ${INITIAL_ADMIN_PASSWORD_PLAIN}"
+}
+
+create_network() {
+    if ! docker network create ${CUSTOM_NETWORK_NAME} &> /dev/null; then
+        echo "Network already exists: ${CUSTOM_NETWORK_NAME}"
+    else
+        echo "Created Docker network: ${CUSTOM_NETWORK_NAME}"
+    fi
+}
+
+gen-certs() {
+    echo "Generating client certificates for TLS-enabled Engine"
+    CERT_PATH=$1
+    if [ -z ${CERT_PATH} ]; then
+        echo "
+          Usage : 
+            gen-certs <docker_client_certificate_path>
+          
+          <docker_client_certificate_path>: 
+            This is the path of the certificate on jenkins slave container
+            to be able to run docker commands against docker swarm.
+            Note - absolute path is required.
+              
+          Example: 
+            gen-certs /root/.docker
+        "
+        exit 1
+    fi
+
+    ####
+    # Windows Git bash terminal identifies 
+    # /CN=client as a path and appends the absolute path 
+    # of parent directory to it
+    ####
+    HOST_OS=$(uname)
+    CLIENT_SUBJ="/CN=client"
+    if echo "${HOST_OS}" | grep -E "MINGW*" >/dev/null
+    then
+        CLIENT_SUBJ="//CN=client"
+    fi
+
+    ####
+    # Fresh start
+    #### 
+    TEMP_CERT_PATH="${HOME}/docker_certs"
+    rm -rf ${TEMP_CERT_PATH}
+    mkdir -p ${TEMP_CERT_PATH}
+
+    ####
+    # * Generate the client private key
+    # * Generate signed certificate
+    # * Generate the client certificate
+    ####
+    openssl genrsa -out ${TEMP_CERT_PATH}/key.pem 4096 &> /dev/null
+    openssl req -subj "${CLIENT_SUBJ}" -new -key ${TEMP_CERT_PATH}/key.pem -out ${TEMP_CERT_PATH}/client.csr &> /dev/null
+    echo "extendedKeyUsage = clientAuth" >  ${TEMP_CERT_PATH}/extfile.cnf
+    openssl x509 -req -days 365 -sha256 -in ${TEMP_CERT_PATH}/client.csr -CA ${HOME}/.docker/machine/certs/ca.pem -CAkey ${HOME}/.docker/machine/certs/ca-key.pem -CAcreateserial -out ${TEMP_CERT_PATH}/cert.pem -extfile ${TEMP_CERT_PATH}/extfile.cnf &> /dev/null
+    cp ${HOME}/.docker/machine/certs/ca.pem ${TEMP_CERT_PATH}/ca.pem
+    docker --tlsverify --tlscacert=${HOME}/.docker/machine/certs/ca.pem --tlscert=${TEMP_CERT_PATH}/cert.pem --tlskey=${TEMP_CERT_PATH}/key.pem -H=${DOCKER_HOST} version &> /dev/null
+
+    ####
+    # * Remove unnecessary files
+    # * Copy the certificates to slave 
+    ####
+    echo "Uploading certificates to Jenkins Slave at: ${CERT_PATH}"
+    rm -f ${TEMP_CERT_PATH}/extfile.cnf ${TEMP_CERT_PATH}/client.csr
+    set +e
+    docker exec jenkins-slave rm -rf ${CERT_PATH}
+    docker cp ${TEMP_CERT_PATH} jenkins-slave:${CERT_PATH}
+    set -e
+}
+
+run_compose() {
+    # Load variables
+    prep_env
+
+    compose_cmd=$1
+    shift
+
+    # If total overrides have been provided then just use them
+    # Else use "our" file list
+    if [ ! -z "${TOTAL_OVERRIDES}"   ]; then
+        docker-compose ${TOTAL_OVERRIDES} ${compose_cmd} "$@"
+    else
+        docker-compose ${ELKFILEOPTS} ${compose_cmd} "$@"
+        echo
+        docker-compose ${ADOPFILEOPTS} ${OVERRIDES} ${compose_cmd} "$@"
+    fi
+}
+
+# Defaults
+DEFAULT_MACHINE_NAME="default"
+export MACHINE_NAME=${DOCKER_MACHINE_NAME:-${DEFAULT_MACHINE_NAME}}
+
+export VOLUME_DRIVER=local
+export LOGGING_DRIVER=syslog
+export CUSTOM_NETWORK_NAME=local_network
+export OVERRIDES=""
+export TOTAL_OVERRIDES=""
+
+# Parameters
+while getopts "m:f:F:v:l:n:i:" opt; do
+  case $opt in
+    m)
+      export MACHINE_NAME=${OPTARG}
+      ;;
+    f)
+      export OVERRIDES="${OVERRIDES} -f ${OPTARG}"
+      ;;
+    F)
+      export TOTAL_OVERRIDES="${TOTAL_OVERRIDES} -f ${OPTARG}"
+      ;;
+    l)
+      export LOGGING_DRIVER="${OPTARG}"
+      ;;
+    v)
+      export VOLUME_DRIVER="${OPTARG}"
+      ;;
+    n)
+      export CUSTOM_NETWORK_NAME="${OPTARG}"
+      ;;
+    i)
+      export PROXY_IP="${OPTARG}"
+      ;;
+    *)
+      echo "Invalid parameter(s) or option(s)."
+      cmd_usage
+      exit 1
+      ;;
+  esac
+done
+
+shift $(($OPTIND -1))
+SUBCOMMAND_OPT="${1:-help}"
+
+# Only shift if there are other parameters
+if [ $# -ge 1 ]; then
+    shift
+fi
+
+# Setting Compose File Lists
+ADOPFILEOPTS="-f ${CLI_DIR}/docker-compose.yml -f ${CLI_DIR}/etc/volumes/${VOLUME_DRIVER}/default.yml -f ${CLI_DIR}/etc/logging/${LOGGING_DRIVER}/default.yml"
+ELKFILEOPTS="-f ${CLI_DIR}/compose/elk.yml"
+
+case ${SUBCOMMAND_OPT} in
+    "cmd_desc"|"help"|"init"|"gen-certs")
+        ${SUBCOMMAND_OPT} "$@"
+        ;;
+    *)
+        run_compose ${SUBCOMMAND_OPT} "$@"
+        ;;
+esac

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1,0 +1,133 @@
+#!/bin/bash -e
+
+echo ' 
+      ###    ########   #######  ########  
+     ## ##   ##     ## ##     ## ##     ## 
+    ##   ##  ##     ## ##     ## ##     ## 
+   ##     ## ##     ## ##     ## ########  
+   ######### ##     ## ##     ## ##        
+   ##     ## ##     ## ##     ## ##        
+   ##     ## ########   #######  ##        
+'
+
+usage(){
+  echo "Usage:"
+  echo "        ./quickstart.sh -t local [-m <MACHINE_NAME>] [-u <INITIAL_ADMIN_USER>] [-p <INITIAL_ADMIN_PASSWORD>]"
+  echo "        ./quickstart.sh -t aws -m <MACHINE_NAME> -c <VPC_ID> [-r <REGION>] [-z <AVAILABILITY_ZONE_LETTER>] [-a <AWS_ACCESS_KEY>] [-s <AWS_SECRET_ACCESS_KEY>] [-u <INITIAL_ADMIN_USER>] [-p <INITIAL_ADMIN_PASSWORD>]"
+}
+
+provision_local() {
+    if [ -z ${MACHINE_NAME} ]; then
+        MACHINE_NAME=adop
+    fi
+
+    # Create Docker machine if one doesn't already exist with the same name
+    if $(docker-machine env $MACHINE_NAME > /dev/null 2>&1) ; then
+        echo "Docker machine '$MACHINE_NAME' already exists"
+    else
+        docker-machine create --driver virtualbox --virtualbox-memory 2048 ${MACHINE_NAME}
+    fi
+}
+
+provision_aws() {
+    if [ -z ${MACHINE_NAME} ] | \
+       [ -z ${VPC_ID} ]; then
+        usage
+        exit 1
+    fi
+
+    if [ -z ${VPC_AVAIL_ZONE} ]; then
+        echo "No availability zone specified - using default [a]."
+        export VPC_AVAIL_ZONE=a
+    elif [[ ! ${VPC_AVAIL_ZONE} =~ ^[a-e]{1,1}$ ]]; then
+            echo "Availability zone can only be a single lower case char, 'a' to 'e'. Exiting..."
+            exit 1
+    fi
+
+    if [ -z ${AWS_ACCESS_KEY_ID} ] & \
+        [ -f ~/.aws/credentials ];
+    then
+      echo "Using default AWS credentials from ~/.aws/credentials"
+      eval $(grep -v '^\[' ~/.aws/credentials | sed 's/^\(.*\)\s=\s/export \U\1=/')
+    fi
+
+    if [ -z ${AWS_DEFAULT_REGION} ] & \
+        [ -f ~/.aws/config ];
+    then
+      echo "Using default AWS region from ~/.aws/config"
+      eval $(grep -v '^\[' ~/.aws/config | sed 's/^\(region\)\s\?=\s\?/export AWS_DEFAULT_REGION=/')
+    fi
+
+    # Create Docker machine if one doesn't already exist with the same name
+    if $(docker-machine env $MACHINE_NAME > /dev/null 2>&1) ; then
+        echo "Docker machine '$MACHINE_NAME' already exists"
+    else
+      if [ -z ${AWS_ACCESS_KEY_ID} ]; then
+        docker-machine create --driver amazonec2 --amazonec2-vpc-id ${VPC_ID} --amazonec2-zone ${VPC_AVAIL_ZONE} --amazonec2-instance-type t2.large ${MACHINE_NAME}
+      else
+        docker-machine create --driver amazonec2 --amazonec2-access-key ${AWS_ACCESS_KEY_ID} --amazonec2-secret-key ${AWS_SECRET_ACCESS_KEY} --amazonec2-vpc-id ${VPC_ID} --amazonec2-zone ${VPC_AVAIL_ZONE} --amazonec2-instance-type t2.large --amazonec2-region ${AWS_DEFAULT_REGION} ${MACHINE_NAME}
+      fi
+    fi
+}
+
+while getopts "t:m:a:s:c:z:r:u:p:" opt; do
+  case ${opt} in
+    t)
+      MACHINE_TYPE=${OPTARG}
+      ;;
+    m)
+      export MACHINE_NAME=${OPTARG}
+      ;;
+    a)
+      export AWS_ACCESS_KEY_ID=${OPTARG}
+      ;;
+    s)
+      export AWS_SECRET_ACCESS_KEY=${OPTARG}
+      ;;
+    c)
+      export VPC_ID=${OPTARG}
+      ;;
+    z)
+      export VPC_AVAIL_ZONE=${OPTARG}
+      ;;
+    r)
+      export AWS_DEFAULT_REGION=${OPTARG}
+      ;;
+    u)
+      export ADMIN_USER=${OPTARG}
+      ;;
+    p)
+      export PASSWORD=${OPTARG}
+      ;;
+    *)
+      echo "Invalid parameter(s) or option(s)."
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z ${MACHINE_TYPE} ]; then
+    echo "Please specify a machine type to create during quickstart"
+    usage
+    exit 1
+fi
+
+# Switch based on the machine type
+case ${MACHINE_TYPE} in
+    "local")
+        provision_local
+        ;;
+    "aws")
+        provision_aws
+        ;;
+    *)
+        echo "Invalid parameter(s) or option(s)."
+        usage
+        exit 1
+        ;;
+esac
+
+# Use the ADOP CLI
+./adop compose -m "${MACHINE_NAME}" init
+


### PR DESCRIPTION
Added in the basic CLI as well as the first sub-command, "compose", so that the startup.sh functionality is fully implemented. Travis will also use the CLI to stand up ADOP locally - a by-product of this is that you can also use the CLI to stand up ADOP against a local Docker Engine without using Docker Machine.

This PR also includes a "quickstart.sh" that will supersede both startup.sh and local-setup.sh by relying on the CLI for standing up ADOP and (for now) just doing the Docker Machine bit depending on the type of machine requested. The intention is for startup.sh and local-setup.sh to be removed, and that in the long run the provisioning aspects of quickstart.sh will also be moved into the CLI.

I've also updated the readme on how to provision manually as I felt this could be improved.