### PR TITLE
Volume on the slave for Docker use during builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,8 +237,6 @@ jenkins-slave:
   restart: always
   image: accenture/adop-jenkins-slave:0.1.3
   net: ${CUSTOM_NETWORK_NAME}
-  volumes:
-    - /var/run/docker.sock:/var/run/docker.sock
   privileged: true
   environment:
     SLAVE_LABELS: "aws ldap java8 docker"

--- a/etc/volumes/local/default.yml
+++ b/etc/volumes/local/default.yml
@@ -48,6 +48,11 @@ sonar:
     - sonar_extensions:/opt/sonarqube/extensions 
     - sonar_logs:/opt/sonarqube/logs
 
+jenkins-slave:
+  volumes:
+    - jenkins_slave_home:/workspace
+    - /var/run/docker.sock:/var/run/docker.sock
+
 jenkins:
   user: root 
   volumes:


### PR DESCRIPTION
If you accept this it will allow people to do things like this in Jenkins jobs:

docker run --rm -v jenkins_slave_home:/jenkins_slave_home/   special_build_container  

i.e. mount the slaves workspace into another container to do work.

NB. the word space is overloaded - it actually means the root of the slave which includes the job folders for all jobs that run on the slave and their individual job workspaces. 

Signed-off-by: Markos Rendell <markosrendell@gmail.com>