### PR TITLE
added --shell param to docker-machine env command

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -95,7 +95,7 @@ else
 fi
 
 # Create Docker network if one doesn't already exist with the same name
-eval "$(docker-machine env $MACHINE_NAME)"
+eval "$(docker-machine env $MACHINE_NAME --shell bash)"
 if ! docker network create $CUSTOM_NETWORK_NAME; then
 	echo "Docker network '$CUSTOM_NETWORK_NAME' already exists"
 fi


### PR DESCRIPTION
as after moving to 1.10 client, env is not auto-detected appropriately in all situations, so this is a small patch to add the --shell=bash param to the docker-machine env call in the script