### PR TITLE
Replace sha256sum command with openssl

### DIFF
--- a/credentials.config.sh
+++ b/credentials.config.sh
@@ -28,6 +28,9 @@ function checkPassword {
 	echo "Your provided password satisfies the strength criteria."
 
 }
+function createPassword {
+    date +%s | openssl sha256 | awk '{print $2}' | base64 | head -c 16; echo
+}
 
 ###############################
 if [ -z $ADMIN_USER ]; then
@@ -47,7 +50,7 @@ fi
 # Else continue checking the input password
 if [ -z $PASSWORD ]; then
  	echo "You have not provided a password. Generating random..."
- 	export PASSWORD=$(date +%s | sha256sum | base64 | head -c 16; echo)
+ 	export PASSWORD=$(createPassword)
  	echo "Your password is $PASSWORD"
 	echo "**Please make note of this as you will use this password to log into all the tools**"
 else
@@ -58,12 +61,12 @@ fi
 export ADMIN_PWD=$(echo -n $PASSWORD | base64)
 
 ###############################
-export PASSWORD_JENKINS=$(date +%s | md5sum | base64 | head -c 16; echo)
+export PASSWORD_JENKINS=$(createPassword)
 export JENKINS_PWD=$(echo -n $PASSWORD_JENKINS | base64)
 
 ###############################
-export PASSWORD_GERRIT=$(date +%s | sha1sum | base64 | head -c 16; echo)
+export PASSWORD_GERRIT=$(createPassword)
 export GERRIT_PWD=$(echo -n $PASSWORD_GERRIT | base64)
 
 ###############################
-export PASSWORD_SQL=$(date +%s | base64 | base64 | head -c 16; echo)
+export PASSWORD_SQL=$(createPassword)

--- a/local-setup.sh
+++ b/local-setup.sh
@@ -58,8 +58,8 @@ docker-compose -f compose/elk.yml up -d
 docker-compose -f docker-compose.yml -f etc/volumes/${VOLUME_DRIVER}/default.yml $LOGGING_OVERRIDE ${OVERRIDES} up -d
 
 # Wait for Jenkins and Gerrit to come up before proceeding
-until [[ $(docker exec jenkins curl -I -s jenkins:jenkins@localhost:8080/jenkins/|head -n 1|cut -d$' ' -f2) == 200 ]]; do echo \"Jenkins unavailable, sleeping for 60s\"; sleep 60; done
-until [[ $(docker exec gerrit curl -I -s gerrit:gerrit@localhost:8080/gerrit/|head -n 1|cut -d$' ' -f2) == 200 ]]; do echo \"Gerrit unavailable, sleeping for 60s\"; sleep 60; done
+until [[ $(docker exec jenkins curl -I -s jenkins:$PASSWORD_JENKINS@localhost:8080/jenkins/|head -n 1|cut -d$' ' -f2) == 200 ]]; do echo \"Jenkins unavailable, sleeping for 60s\"; sleep 60; done
+until [[ $(docker exec gerrit curl -I -s gerrit:$PASSWORD_GERRIT@localhost:8080/gerrit/|head -n 1|cut -d$' ' -f2) == 200 ]]; do echo \"Gerrit unavailable, sleeping for 60s\"; sleep 60; done
 
 # Trigger Load_Platform in Jenkins
 docker exec jenkins curl -X POST jenkins:$PASSWORD_JENKINS@localhost:8080/jenkins/job/Load_Platform/buildWithParameters \


### PR DESCRIPTION
The sha256sum command doesn't exist on OS X, so this script would fail. I replaced it with the openssl command which is more universal. Also refactored all of the password generation to a single function.

Additionally, I found a problem with the local-setup.sh script not using the right passwords. Corrected and added to this pull request.