### PR TITLE
Fixed credential variable names in quickstart.sh

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -94,10 +94,10 @@ while getopts "t:m:a:s:c:z:r:u:p:" opt; do
       export AWS_DEFAULT_REGION=${OPTARG}
       ;;
     u)
-      export ADMIN_USER=${OPTARG}
+      export INITIAL_ADMIN_USER=${OPTARG}
       ;;
     p)
-      export PASSWORD=${OPTARG}
+      export INITIAL_ADMIN_PASSWORD_PLAIN=${OPTARG}
       ;;
     *)
       echo "Invalid parameter(s) or option(s)."


### PR DESCRIPTION
Admin user and password variable names were not updated in quickstart.sh and hence were not being picked up by credentials.generate.sh.
Updated to INITIAL_ADMIN_USER  and INITIAL_ADMIN_PASSWORD_PLAIN now, same as startup.sh and local-setup.sh