### PR TITLE
fix quickstart execution in Windows

### DIFF
--- a/cmd/compose
+++ b/cmd/compose
@@ -44,7 +44,7 @@ prep_env() {
                exit 1
             else
                 # Set the machine
-                eval $( docker-machine env $MACHINE_NAME )
+                eval $(docker-machine env $MACHINE_NAME --shell bash)
 
                 export TARGET_HOST=$(docker-machine ip $MACHINE_NAME)
                 export LOGSTASH_HOST=$(docker-machine ip $MACHINE_NAME)


### PR DESCRIPTION
added '--shell bash' parameter to 'docker-machine env' command to ensure smooth execution while on Windows Mingw-based bash shell

symptom: this error appears in console
* Initialising ADOP
./cmd/compose: eval: line 47: syntax error near unexpected token `('

after fix is applied: ADOP machine is provisioned and fully functional as expected