### PR TITLE
Increasing default AWS instance size to support FOSS Java updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The platform is designed to run on any container platform.
 
 - Create a Docker Engine in AWS (replace the placeholders and their <> markers): 
 ```sh
-docker-machine create --driver amazonec2 --amazonec2-access-key <YOUR_ACCESS_KEY> --amazonec2-secret-key <YOUR_SECRET_KEY> --amazonec2-vpc-id <YOUR_VPC_ID> --amazonec2-instance-type t2.large --amazonec2-region <YOUR_AWS_REGION, e.g. eu-west-1> <YOUR_MACHINE_NAME>
+docker-machine create --driver amazonec2 --amazonec2-access-key <YOUR_ACCESS_KEY> --amazonec2-secret-key <YOUR_SECRET_KEY> --amazonec2-vpc-id <YOUR_VPC_ID> --amazonec2-instance-type m4.xlarge --amazonec2-region <YOUR_AWS_REGION, e.g. eu-west-1> <YOUR_MACHINE_NAME>
 ```
 
 - Update the docker-machine security group to permit inbound http traffic on port 80 (from the machine(s) from which you want to have access only), also UDP on 25826 and 12201 from 127.0.0.1/32

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -63,9 +63,9 @@ provision_aws() {
         echo "Docker machine '$MACHINE_NAME' already exists"
     else
       if [ -z ${AWS_ACCESS_KEY_ID} ]; then
-        docker-machine create --driver amazonec2 --amazonec2-vpc-id ${VPC_ID} --amazonec2-zone ${VPC_AVAIL_ZONE} --amazonec2-instance-type t2.large ${MACHINE_NAME}
+        docker-machine create --driver amazonec2 --amazonec2-vpc-id ${VPC_ID} --amazonec2-zone ${VPC_AVAIL_ZONE} --amazonec2-instance-type m4.xlarge ${MACHINE_NAME}
       else
-        docker-machine create --driver amazonec2 --amazonec2-access-key ${AWS_ACCESS_KEY_ID} --amazonec2-secret-key ${AWS_SECRET_ACCESS_KEY} --amazonec2-vpc-id ${VPC_ID} --amazonec2-zone ${VPC_AVAIL_ZONE} --amazonec2-instance-type t2.large --amazonec2-region ${AWS_DEFAULT_REGION} ${MACHINE_NAME}
+        docker-machine create --driver amazonec2 --amazonec2-access-key ${AWS_ACCESS_KEY_ID} --amazonec2-secret-key ${AWS_SECRET_ACCESS_KEY} --amazonec2-vpc-id ${VPC_ID} --amazonec2-zone ${VPC_AVAIL_ZONE} --amazonec2-instance-type m4.xlarge --amazonec2-region ${AWS_DEFAULT_REGION} ${MACHINE_NAME}
       fi
     fi
 }

--- a/startup.sh
+++ b/startup.sh
@@ -124,9 +124,9 @@ if $(docker-machine env $MACHINE_NAME > /dev/null 2>&1) ; then
 	echo "Docker machine '$MACHINE_NAME' already exists"
 else
   if [ -z $AWS_ACCESS_KEY_ID ]; then
-    docker-machine create --driver amazonec2 --amazonec2-vpc-id $VPC_ID --amazonec2-zone $VPC_AVAIL_ZONE --amazonec2-instance-type t2.large $MACHINE_NAME
+    docker-machine create --driver amazonec2 --amazonec2-vpc-id $VPC_ID --amazonec2-zone $VPC_AVAIL_ZONE --amazonec2-instance-type m4.xlarge $MACHINE_NAME
   else
-    docker-machine create --driver amazonec2 --amazonec2-access-key $AWS_ACCESS_KEY_ID --amazonec2-secret-key $AWS_SECRET_ACCESS_KEY --amazonec2-vpc-id $VPC_ID --amazonec2-zone $VPC_AVAIL_ZONE --amazonec2-instance-type t2.large --amazonec2-region $AWS_DEFAULT_REGION $MACHINE_NAME
+    docker-machine create --driver amazonec2 --amazonec2-access-key $AWS_ACCESS_KEY_ID --amazonec2-secret-key $AWS_SECRET_ACCESS_KEY --amazonec2-vpc-id $VPC_ID --amazonec2-zone $VPC_AVAIL_ZONE --amazonec2-instance-type m4.xlarge --amazonec2-region $AWS_DEFAULT_REGION $MACHINE_NAME
   fi
 fi
 


### PR DESCRIPTION
Increasing default AWS instance size to support FOSS Java updates. A t2.large is not big enough to support three Tomcat environments running Pet Clinic so I've increased the size to an m4.xlarge. As the last two environments have manual triggers for their deployments it is still possible to run on a smaller instance, just without the full functionality of the pipeline.