### PR TITLE
Updating Jenkins image version number to 0.1.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,7 +194,7 @@ sonar:
 jenkins:
   container_name: jenkins
   restart: always
-  image: accenture/adop-jenkins:0.1.2
+  image: accenture/adop-jenkins:0.1.4
   #build: ../images/docker-jenkins/
   net: ${CUSTOM_NETWORK_NAME}
   expose:


### PR DESCRIPTION
New Jenkins image has default permissions to approve some standard Java methods to use in Pipeline jobs.