### PR TITLE
Adding a mechanism to provide Jenkins with AWS parameters in override file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ volumes/jenkins-home-vol
 *.swp
 *.swo
 platform.secrets.sh
+conf/provider/env.provider.*.sh

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Once you have explored this the next step is to create your own Workspace and Pr
 
 These instructions will spin up an instance in a single server in AWS (for evaluation purposes).
 
-NB. the instructions will also work in anywhere supported by [Docker Machine](https://docs.docker.com/machine/), just follow the relevant Docker Machine instructions for your target platform and then start at step 3 below and (you can set the VPC_ID to NA).
+NB. the instructions will also work in anywhere supported by [Docker Machine](https://docs.docker.com/machine/), just follow the relevant Docker Machine instructions for your target platform and then start at step 3 below and (you can set the AWS_VPC_ID to NA).
 
 1. Create a VPC using the [VPC wizard](http://docs.aws.amazon.com/AmazonVPC/latest/GettingStartedGuide/getting-started-create-vpc.html) in the AWS console by selecting the first option with 1 public subnet.
 1. On the "Step 2: VPC with a Single Public Subnet" page give your VPC a meaningful name and specify the availability zone as 'a', e.g. select eu-west-1a from the pulldown.
@@ -35,8 +35,8 @@ NB. the instructions will also work in anywhere supported by [Docker Machine](ht
         $ ./quickstart.sh
         Usage: ./quickstart.sh -t aws
                                -m <MACHINE_NAME>  
-                               -c <VPC_ID> 
-                               -r <REGION>(optional) 
+                               -c <AWS_VPC_ID> 
+                               -r <AWS_DEFAULT_REGION>(optional) 
                                -z <VPC_AVAIL_ZONE>(optional)
                                -a <AWS_ACCESS_KEY>(optional) 
                                -s <AWS_SECRET_ACCESS_EY>(optional) 
@@ -51,7 +51,8 @@ NB. the instructions will also work in anywhere supported by [Docker Machine](ht
                 - your AWS key and your secret access key (see [getting your AWS access key](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html)) via command line options, environment variables or using aws configure 
                 - the AWS region id in this format: eu-west-1
             - a username and password (optional) to act as credentials for the initial admin user (you will be prompted to re-enter your password if it is considered weak)
-                - Initial admin user can not be set to 'admin' to avoid duplicate entries in LDAP.
+                - The initial admin username cannot be set to 'admin' to avoid duplicate entries in LDAP.
+            - AWS parameters i.e. a subnet ID, the name of a keypair and an EC2 instance type (these parameters are useful if you would like to extend the platform with additional AWS EC2 services)
     - For example (if you don't have ~/.aws set up):
 
         ```./quickstart.sh -t aws -m adop1 -a AAA -s BBB -c vpc-123abc -r eu-west-1 -u user.name -p userPassword```
@@ -65,9 +66,10 @@ NB. the instructions will also work in anywhere supported by [Docker Machine](ht
     SUCCESS, your new ADOP instance is ready!
 
     Run this command in your shell:
-      source env.config.sh
+      source ./conf/env.provider.sh
       source credentials.generate.sh
-
+      source env.config.sh
+      
     You can check if any variables are missing with: ./adop compose config  | grep 'WARNING'
 
     Navigate to http://11.22.33.44 in your browser to use your new DevOps Platform!
@@ -127,6 +129,10 @@ Create a Docker Swarm that has a publicly accessible Engine with the label "tier
 - Create a custom network: docker network create $CUSTOM\_NETWORK\_NAME
 - Run: docker-compose -f compose/elk.yml up -d
 - Run: export LOGSTASH\_HOST=\<IP\_OF\_LOGSTASH\_HOST\>
+- Source all the required parameters for your chosen cloud provider.
+    - For example, for AWS you will need to source AWS_VPC_ID, AWS_SUBNET_ID, AWS_KEYPAIR, AWS_INSTANCE_TYPE and AWS_DEFAULT_REGION. To do this, make a copy of the env.aws.provider.sh.example file in /conf/provider/examples and save it as env.provider.aws.sh in /conf/provider. You can then replace all the tokens with your values.
+    - You should then run: source ./conf/env.provider.sh (this will source all the provider-specific environment variable files you have specified).
+    - The provider-specific environment variable files should not be uploaded to a remote repository, hence they should not be removed from the .gitignore file.
 - Run: source credentials.generate.sh \[This creates a file containing your generated passwords, platform.secrets.sh, which is sourced. If the file already exists, it will not be created.\]
     - platform.secrets.sh should not be uploaded to a remote repository hence **do not remove this file from the .gitignore file**
 - Run: source env.config.sh
@@ -151,7 +157,8 @@ Create a Docker Swarm that has a publicly accessible Engine with the label "tier
 
 Create ssl certificate for jenkins to allow connectivity with docker engine.
 
-* RUN : credentials.generate.sh
+* RUN : source ./conf/env.provider.sh
+* RUN : source credentials.generate.sh
 * RUN : source env.config.sh
 * RUN : ./generate\_client\_certs.sh ${DOCKER\_CLIENT\_CERT\_PATH}
 

--- a/adop
+++ b/adop
@@ -6,6 +6,7 @@ CMD_NAME=`basename "$0"`
 # This helps our Windows users, while not bothering our Unix users.
 export CLI_DIR=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
 export CONF_DIR="${CLI_DIR}"
+export CONF_PROVIDER_DIR="${CLI_DIR}/conf/provider"
 CLI_CMD_DIR="${CLI_DIR}/cmd"
 
 usage() {

--- a/cmd/compose
+++ b/cmd/compose
@@ -61,6 +61,7 @@ prep_env() {
         export LOGSTASH_HOST=${PROXY_IP}
     fi
 
+    source ${CONF_DIR}/conf/env.provider.sh
     source ${CONF_DIR}/credentials.generate.sh
     source ${CONF_DIR}/env.config.sh
 }
@@ -128,9 +129,10 @@ esac
     echo
     echo "SUCCESS, your new ADOP instance is ready!"
     echo
-    echo "Run this command in your shell:"
-    echo '  source env.config.sh'
+    echo "Run these commands in your shell:"
+    echo '  source ./conf/env.provider.sh'
     echo '  source credentials.generate.sh'
+    echo '  source env.config.sh'
     echo
     echo "You can check if any variables are missing with: ./adop compose config  | grep 'WARNING'"
     echo

--- a/conf/env.provider.sh
+++ b/conf/env.provider.sh
@@ -1,0 +1,11 @@
+# Environment file which sources other provider-specific environment files
+
+echo "Sourcing provider-specific environment files..."
+
+for p in $(ls ${CONF_PROVIDER_DIR}/env.provider.*.sh 2> /dev/null);
+do
+	if [ -f ${p} ]; then
+		echo "Sourcing ${p} parameters file..."
+		source ${p}
+	fi
+done

--- a/conf/provider/examples/env.provider.aws.sh.example
+++ b/conf/provider/examples/env.provider.aws.sh.example
@@ -1,0 +1,8 @@
+# Shell script to store AWS-specific environment variables
+# Can be sourced and re-sourced to keep variables in shell instance
+
+export AWS_VPC_ID="###AWS_VPC_ID###"
+export AWS_KEYPAIR="###AWS_KEYPAIR###"
+export AWS_INSTANCE_TYPE="###AWS_INSTANCE_TYPE###"
+export AWS_SUBNET_ID="###AWS_SUBNET_ID###"
+export AWS_DEFAULT_REGION="###AWS_DEFAULT_REGION###"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,7 +194,7 @@ sonar:
 jenkins:
   container_name: jenkins
   restart: always
-  image: accenture/adop-jenkins:0.1.4
+  image: accenture/adop-jenkins:0.1.5
   #build: ../images/docker-jenkins/
   net: ${CUSTOM_NETWORK_NAME}
   expose:

--- a/etc/aws/default.yml
+++ b/etc/aws/default.yml
@@ -1,0 +1,9 @@
+# Override file to pass in AWS specific env variables to jenkins
+
+jenkins:
+  environment:
+    AWS_KEYPAIR: "${AWS_KEYPAIR}"
+    AWS_VPC_ID: "${AWS_VPC_ID}"
+    AWS_SUBNET_ID: "${AWS_SUBNET_ID}"
+    AWS_INSTANCE_TYPE: "${AWS_INSTANCE_TYPE}"
+    AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION}"


### PR DESCRIPTION
- More flags added to allow users to specify AWS parameters such as subnet ID, EC2 instance type and AWS keypair
- Variables are then passed to an override yaml file which is picked up by jenkins and jenkins-slave when provisioning on AWS
- Function added which takes AWS variables and places them in a shell script which can be sourced to export all the AWS variables (this shell script needs to be deleted if new AWS parameters are to be used)