### PR TITLE
Adding ADOP_PLATFORM_MANAGEMENT_VERSION to Jenkins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,6 +202,7 @@ jenkins:
     - "50000"
   privileged: true
   environment:
+    ADOP_PLATFORM_MANAGEMENT_VERSION: "0.1.1"
     JENKINS_OPTS: "--prefix=/jenkins"
     ROOT_URL: "${PROTO}://${TARGET_HOST}/jenkins/"
     LDAP_SERVER: "ldap:389"


### PR DESCRIPTION
Adding ADOP_PLATFORM_MANAGEMENT_VERSION to Jenkins in preparation for it's usage to specify the version of adop-platform-management to use in the platform jobs.