### PR TITLE
Added check to make sure INITIAL_ADMIN_USER is not set to 'admin'

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ NB. the instructions will also work in anywhere supported by [Docker Machine](ht
                 - your AWS key and your secret access key (see [getting your AWS access key](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html)) via command line options, environment variables or using aws configure 
                 - the AWS region id in this format: eu-west-1
             - a username and password (optional) to act as credentials for the initial admin user (you will be prompted to re-enter your password if it is considered weak)
+                - Initial admin user can not be set to 'admin' to avoid duplicate entries in LDAP.
     - For example (if you don't have ~/.aws set up):
 
         ```./quickstart.sh -t aws -m adop1 -a AAA -s BBB -c vpc-123abc -r eu-west-1 -u user.name -p userPassword```

--- a/credentials.generate.sh
+++ b/credentials.generate.sh
@@ -51,11 +51,11 @@ else
 	cp ./platform.secrets.sh.example ./platform.secrets.sh
 	
 	# Check for username, prompt one if not entered and write it to secrets file
-	if [ -z $INITIAL_ADMIN_USER ]; then
-		echo "You have not provided a user name. Please enter a username: "
+	if [ -z $INITIAL_ADMIN_USER -o "$INITIAL_ADMIN_USER" == "admin" ]; then
+		echo "You have entered invalid username. Username can not be blank or 'admin'. Please enter a valid username: "
 		read INITIAL_ADMIN_USER
-		while [ "$INITIAL_ADMIN_USER" == "" ]; do
-			echo "You have not entered a username. Try again..."
+		while [ "$INITIAL_ADMIN_USER" == "" -o "$INITIAL_ADMIN_USER" == "admin" ]; do
+			echo "You have entered invalid username. Username can not be blank or 'admin'. Try again..."
 			read INITIAL_ADMIN_USER
 		done
 		export INITIAL_ADMIN_USER

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ ldap:
   container_name: ldap
   restart: always
   #build: ../images/docker-ldap/
-  image: accenture/adop-ldap:0.1.1
+  image: accenture/adop-ldap:0.1.2
   net: ${CUSTOM_NETWORK_NAME}
   expose:
     - "389"


### PR DESCRIPTION
Setting the INITIAL_ADMIN_USER to 'admin' creates entries in ldap with same common name and gerrit authentication doesn't work. To avoid such duplicate entries added check in credentials.generate.sh script to make sure INITIAL_ADMIN_USER is not set to 'admin'