### PR TITLE
Added ports for windows SAP slave as 8080 and 50000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,9 +197,12 @@ jenkins:
   image: accenture/adop-jenkins:0.1.2
   #build: ../images/docker-jenkins/
   net: ${CUSTOM_NETWORK_NAME}
-  expose:
-    - "8080"
-    - "50000"
+  #expose:
+   # - "8080"
+    #- "50000"
+  ports:
+    - "8080:8080"
+    - "50000:50000"
   privileged: true
   environment:
     JENKINS_OPTS: "--prefix=/jenkins"


### PR DESCRIPTION
Changed the docker-compose.yml to include ports 8080 and 50000 for setting up jenkins slave.
