### PR TITLE
Adding minor bug fixes

### DIFF
--- a/cmd/compose
+++ b/cmd/compose
@@ -193,12 +193,38 @@ gen-certs() {
     # * Generate signed certificate
     # * Generate the client certificate
     ####
+    set +e
     openssl genrsa -out ${TEMP_CERT_PATH}/key.pem 4096 &> /dev/null
     openssl req -subj "${CLIENT_SUBJ}" -new -key ${TEMP_CERT_PATH}/key.pem -out ${TEMP_CERT_PATH}/client.csr &> /dev/null
     echo "extendedKeyUsage = clientAuth" >  ${TEMP_CERT_PATH}/extfile.cnf
     openssl x509 -req -days 365 -sha256 -in ${TEMP_CERT_PATH}/client.csr -CA ${HOME}/.docker/machine/certs/ca.pem -CAkey ${HOME}/.docker/machine/certs/ca-key.pem -CAcreateserial -out ${TEMP_CERT_PATH}/cert.pem -extfile ${TEMP_CERT_PATH}/extfile.cnf &> /dev/null
+    set -e
+    CERT_FILE="${TEMP_CERT_PATH}/cert.pem"
+    if [[ -s $CERT_FILE ]]; then
+        echo "$CERT_FILE was generated successfully."
+    else
+        echo "$CERT_FILE was not created successfully and is empty."
+        echo "This is because you have not run your shell window in Administrator mode or with root access."
+        echo "Please run your shell window in Administrator mode or with root access and re-run the quickstart script with the same flags provided in this run."
+        exit 1
+    fi
     cp ${HOME}/.docker/machine/certs/ca.pem ${TEMP_CERT_PATH}/ca.pem
     docker --tlsverify --tlscacert=${HOME}/.docker/machine/certs/ca.pem --tlscert=${TEMP_CERT_PATH}/cert.pem --tlskey=${TEMP_CERT_PATH}/key.pem -H=${DOCKER_HOST} version &> /dev/null
+
+    ####
+    # * Check if certificates were generated successfully
+    ####
+    CA_FILE="${TEMP_CERT_PATH}/ca.pem"
+    KEY_FILE="${TEMP_CERT_PATH}/key.pem"
+    for file in $CA_FILE $KEY_FILE
+    do
+        if [[ -s $file ]]; then
+            echo "${file} was generated successfully..."
+        else
+            echo "${file} was not generated successfully..."
+            exit 1
+        fi
+    done
 
     ####
     # * Remove unnecessary files

--- a/conf/env.provider.sh
+++ b/conf/env.provider.sh
@@ -2,7 +2,12 @@
 
 echo "Sourcing provider-specific environment files..."
 
-for p in $(ls ${CONF_PROVIDER_DIR}/env.provider.*.sh 2> /dev/null);
+PROVIDER_DIR=${CONF_PROVIDER_DIR:-./conf/provider}
+if [ ! -d "$PROVIDER_DIR" ]; then
+	echo "${PROVIDER_DIR} is not a valid directory accessible from your current location."
+fi
+
+for p in $(ls ${PROVIDER_DIR}/env.provider.*.sh 2> /dev/null);
 do
 	if [ -f ${p} ]; then
 		echo "Sourcing ${p} parameters file..."


### PR DESCRIPTION
Bug fixes:

- Certificate generation will now exit with a helpful message if bash is not run as admin (openssl command to create a cert will fail since it needs to source a .srl file)
- Fix to allow "source ./conf/env.provider.sh" to be run if CONF_PROVIDER_DIR is not set, where we just use the current directory as a reference