### PR TITLE
Bug fix by removing unneccesary double quotes in quickstart

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -223,4 +223,4 @@ case ${MACHINE_TYPE} in
 esac
 
 # Use the ADOP CLI
-./adop compose -m "${MACHINE_NAME}" "${CLI_COMPOSE_OPTS}" init
+./adop compose -m "${MACHINE_NAME}" ${CLI_COMPOSE_OPTS} init


### PR DESCRIPTION
Minor bug fix by removing the quotes around CLI_COMPOSE_OPTS

For aws we set it to "-f /etc...." but for local it will be defaulted to "", hence when we ran for local
./adop compose -m "${MACHINE_NAME}" ${CLI_COMPOSE_OPTS} init 
what it was actually running was
./adop compose -m <machine_name> '' init
which caused it to stop just before the adop init step.