### PR TITLE
gen-certs is not a valid identifier

### DIFF
--- a/cmd/compose
+++ b/cmd/compose
@@ -118,7 +118,7 @@ esac
 
     # Generate and copy the certificates to jenkins slave if TLS is enabled
     if [ "${DOCKER_TLS_VERIFY}" = "1" ]; then
-        gen-certs "${DOCKER_CLIENT_CERT_PATH}"
+        gen_certs "${DOCKER_CLIENT_CERT_PATH}"
     else
         echo "DOCKER_TLS_VERIFY not set to 1, skipping certificate generation"
     fi
@@ -150,7 +150,7 @@ create_network() {
     fi
 }
 
-gen-certs() {
+gen_certs() {
     echo "Generating client certificates for TLS-enabled Engine"
     CERT_PATH=$1
     if [ -z ${CERT_PATH} ]; then
@@ -312,7 +312,7 @@ ADOPFILEOPTS="-f ${CLI_DIR}/docker-compose.yml -f ${CLI_DIR}/etc/volumes/${VOLUM
 ELKFILEOPTS="-f ${CLI_DIR}/compose/elk.yml"
 
 case ${SUBCOMMAND_OPT} in
-    "cmd_desc"|"help"|"init"|"gen-certs")
+    "cmd_desc"|"help"|"init"|"gen_certs")
         ${SUBCOMMAND_OPT} "$@"
         ;;
     *)


### PR DESCRIPTION
Function names with the dash "-" sign are not allowed in bash, according to bash itself (see error below) as well as the Bash scripting guide at http://tldp.org/LDP/abs/html/gotchas.html.

I'm surprised that the adop script has ever worked before:

```bash
++ basename ./adop
+ CMD_NAME=adop
+++ echo ./adop
+++ sed -e 's,\\,/,g'
++ dirname ./adop
+ export CLI_DIR=.
+ CLI_DIR=.
+ export CONF_DIR=.
+ CONF_DIR=.
+ export CONF_PROVIDER_DIR=./conf/provider
+ CONF_PROVIDER_DIR=./conf/provider
+ CLI_CMD_DIR=./cmd
+ main compose gen-certs /Users/oscar.renalias/.foo
+ '[' 3 -lt 1 ']'
+ SUBCOMMAND=compose
+ shift
+ '[' '!' -e ./cmd/compose ']'
+ . ./cmd/compose gen-certs /Users/oscar.renalias/.foo
++ SUB_CMD_NAME=compose
./cmd/compose: line 239: `gen-certs': not a valid identifier
```

This was the output of `sh -x ./adop compose gen-certs ~/.foo`.

The attached pull request fixes the problem but please note that the "gen-certs" commands is also renamed to "gen_certs" unless the current command delegation logic is changed. I have not updated any documentation.