### PR TITLE
Fixing bug in username checking

### DIFF
--- a/credentials.generate.sh
+++ b/credentials.generate.sh
@@ -51,11 +51,11 @@ else
 	cp ./platform.secrets.sh.example ./platform.secrets.sh
 	
 	# Check for username, prompt one if not entered and write it to secrets file
-	if [ -z $INITIAL_ADMIN_USER -o "$INITIAL_ADMIN_USER" == "admin" ]; then
-		echo "You have entered invalid username. Username can not be blank or 'admin'. Please enter a valid username: "
+	if [[ -z $INITIAL_ADMIN_USER ]] || [[ ${INITIAL_ADMIN_USER} = "admin" ]]; then
+		echo "You have entered an invalid username. Username can not be blank or 'admin'. Please enter a valid username: "
 		read INITIAL_ADMIN_USER
-		while [ "$INITIAL_ADMIN_USER" == "" -o "$INITIAL_ADMIN_USER" == "admin" ]; do
-			echo "You have entered invalid username. Username can not be blank or 'admin'. Try again..."
+		while [[ -z $INITIAL_ADMIN_USER ]] || [[ ${INITIAL_ADMIN_USER} = "admin" ]]; do
+			echo "You have entered an invalid username. Username can not be blank or 'admin'. Try again..."
 			read INITIAL_ADMIN_USER
 		done
 		export INITIAL_ADMIN_USER


### PR DESCRIPTION
Problem was when a blank username was provided, it wasn't being flagged up as an error. This may have been due to a problem with combining the -z flag with the -o flag.

Reverted back to using a simple conditional statement with an "OR" operator.