### PR TITLE
Added version tag to sensu-uchiwa image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ gerrit:
 sensu-uchiwa:
   container_name: sensu-uchiwa
   restart: always
-  image: sstarcher/uchiwa
+  image: sstarcher/uchiwa:0.15.0
   net: ${CUSTOM_NETWORK_NAME}
   environment:
     SENSU_HOSTNAME: sensu-api


### PR DESCRIPTION
Issue https://github.com/Accenture/adop-docker-compose/issues/98 that the uchiwa container cannot deploy fixed by adding a version tag (0.15.0)