### PR TITLE
Updated outer-proxy image version to 0.2.0

### DIFF
--- a/provision/aws/swarm/CF-ADOP-Cluster.json
+++ b/provision/aws/swarm/CF-ADOP-Cluster.json
@@ -1905,7 +1905,7 @@
               { "Fn::GetAtt": [ "ProxyPrivateElasticLoadBalancer", "DNSName" ] },
               " -e SWARM_MASTER_HOST=",
               { "Fn::GetAtt": [ "MasterSwarmInstance", "PrivateIp" ] },
-              " -e SWARM_MASTER_PORT=2375 --name=outer-proxy-nginx -d accenture/adop-outer-proxy:0.1.0 \n"
+              " -e SWARM_MASTER_PORT=2375 --name=outer-proxy-nginx -d accenture/adop-outer-proxy:0.2.0 \n"
               ]
             ]
           }


### PR DESCRIPTION
Updated SWARM CF template to use latest (0.2.0) version of the adop-outer-proxy image