### PR TITLE
Adding environment variable required in new uchiwa version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,7 @@ sensu-uchiwa:
   net: ${CUSTOM_NETWORK_NAME}
   environment:
     SENSU_HOSTNAME: sensu-api
+    SENSU_DC_NAME: Sensu
   expose:
     - "3000"
 


### PR DESCRIPTION
Adding SENSU_DC_NAME variable which is required in https://github.com/sstarcher/docker-uchiwa/blob/master/templates/config.json.tmpl#L2 .