### PR TITLE
Update version of ADOP SonarQube docker image to 0.2.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ sonar-mysql:
 sonar:
   container_name: sonar
   restart: always
-  image: accenture/adop-sonar:0.1.1
+  image: accenture/adop-sonar:0.2.0
   #build: ../images/docker-sonar/
   net: ${CUSTOM_NETWORK_NAME}
   expose:


### PR DESCRIPTION
SonarQube image was updated:
- https://github.com/Accenture/adop-sonar/releases/tag/0.2.0
- https://hub.docker.com/r/accenture/adop-sonar/tags/