### PR TITLE
Adding option to skip Load_Platform

### DIFF
--- a/cmd/compose
+++ b/cmd/compose
@@ -23,6 +23,7 @@ help() {
     echo
     echo "Available subcommands are:"
     printf "    %-22s   %s\n" "init" "Initialises ADOP"
+    printf "    %-22s   %s\n" "init <--without-load>" "Initialises ADOP without loading the platform"
     printf "    %-22s   %s\n" "init <--without-pull>" "Initialises ADOP without pulling images"
     printf "    %-22s   %s\n" "up" "docker-compose up for ADOP"
     printf "    %-22s   %s\n" "gen-certs <path>" "Generate client certificates for TLS-enabled Machine and copy to <path> in Jenkins Slave"
@@ -88,7 +89,10 @@ case "$1" in
     --without-pull)
         export PULL="NO"
         ;;
-        *)
+    --without-load)
+        export LOAD="NO"
+        ;;
+    *)
 esac
 
     echo ' 
@@ -129,8 +133,12 @@ esac
     until [[ $(docker exec gerrit curl -I -s gerrit:${PASSWORD_GERRIT}@localhost:8080/gerrit/|head -n 1|cut -d$' ' -f2) == 200 ]]; do pretty_sleep ${TOOL_SLEEP_TIME} Gerrit; done
     
     # Trigger Load_Platform in Jenkins
-    echo "* Initialising the Platform"
-    docker exec jenkins curl -s -X POST jenkins:${PASSWORD_JENKINS}@localhost:8080/jenkins/job/Load_Platform/buildWithParameters --data token=gAsuE35s
+    if [ "${LOAD}" = "NO" ]; then
+        echo "* Skipping Loading the Platform"
+    else
+        echo "* Loading the Platform"
+        docker exec jenkins curl -s -X POST jenkins:${PASSWORD_JENKINS}@localhost:8080/jenkins/job/Load_Platform/buildWithParameters --data token=gAsuE35s
+    fi
 
     # Generate and copy the certificates to jenkins slave if TLS is enabled
     if [ "${DOCKER_TLS_VERIFY}" = "1" ]; then


### PR DESCRIPTION
Adding an option to compose init to pass "--without-load" that prevents the Load_Platform job from being called. This is useful if you want to override the URL it will use for adop-platform-management, such as during development where a fork is preferred.