### PR TITLE
Travis: Upgrading Compose to 1.6.2 for bug fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 env:
   global:
-    - DOCKER_COMPOSE_VERSION=1.6.0
+    - DOCKER_COMPOSE_VERSION=1.6.2
     - INITIAL_ADMIN_USER=admin.user
     - INITIAL_ADMIN_PASSWORD_PLAIN=admin123
     - COMPOSE_FILES="-f site/docker-compose.yml"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Once you have explored this the next step is to create your own Workspace and Pr
 
 # Quickstart Instructions
 
-These instructions will spin up an instance in a single server in AWS (for evaluation purposes).
+These instructions will spin up an instance in a single server in AWS (for evaluation purposes).  Please check the [prerequisites](http://accenture.github.io/adop-docker-compose/docs/prerequisites/).
 
 NB. the instructions will also work in anywhere supported by [Docker Machine](https://docs.docker.com/machine/), just follow the relevant Docker Machine instructions for your target platform and then start at step 3 below and (you can set the AWS_VPC_ID to NA).
 

--- a/site/_docs/prerequisites.md
+++ b/site/_docs/prerequisites.md
@@ -11,5 +11,8 @@ To run ADOP in evaluation mode you will need:
     * Docker Toolbox can install Git Bash for you
 * Docker & Docker Compose
     * Can be installed separately or via Docker Toolbox
+    * Docker Engine 1.9.1
+    * Docker Compose 1.6.2
 * Docker Machine
     * Only required for evaluation mode
+    * Docker Machine 0.6.0

--- a/site/_docs/quickstart.md
+++ b/site/_docs/quickstart.md
@@ -4,7 +4,7 @@ title: Quickstart
 permalink: /docs/quickstart/
 ---
 
-These instructions will spin up an instance in a single server in AWS (for evaluation purposes).
+These instructions will spin up an instance in a single server in AWS (for evaluation purposes). Please check the [prerequisites](/adop-docker-compose/docs/prerequisites/).
 
 NB. the instructions will also work in anywhere supported by [Docker Machine](https://docs.docker.com/machine/), just follow the relevant Docker Machine instructions for your target platform and then start at step 3 below and (you can set the VPC_ID to NA).
 


### PR DESCRIPTION
Upgrading Compose to 1.6.2 for bug fixes in Travis