### PR TITLE
Removing checking if target URL contains an IP

### DIFF
--- a/cmd/target
+++ b/cmd/target
@@ -69,12 +69,10 @@ set_target() {
       set +e
       URL_RC=$(curl --max-time 60 -I -s -u ${ADOP_CLI_USER}:${ADOP_CLI_PASSWORD} ${ADOP_CLI_ENDPOINT})
       CMD_RC=$?
-      CMD=$(echo ${ADOP_CLI_ENDPOINT} | egrep 'http://[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/?$')
-      CMD_RC=$(($CMD_RC + $?))
       set -e
 
       if [ ${CMD_RC} != 0 ] ; then
-          echo "ERROR: ENDPOINT ${ADOP_CLI_ENDPOINT} is invalid. Check the endpoint url."
+          echo "ERROR: ENDPOINT ${ADOP_CLI_ENDPOINT} is invalid - return code ${CMD_RC}. Check the endpoint url."
           exit 2
       elif [ $(echo ${URL_RC} |head -n 1|cut -d$' ' -f2) != 200 ]; then
           echo "ERROR: ENDPOINT ${ADOP_CLI_ENDPOINT} is inaccessible using CLI credentials ${ADOP_CLI_USER}:${ADOP_CLI_PASSWORD}. Check the endpoint and credentials"
@@ -115,4 +113,3 @@ if [ ! -z ${SUBCOMMAND_OPT} ]; then
         ;;
   esac
 fi
-


### PR DESCRIPTION
The adop target command was previously validating that the target endpoint contained an IP when actually this is more restrictive than we need as both hostnames and full domain names should be valid endpoints.