### PR TITLE
Fix: #121

### DIFF
--- a/cmd/compose
+++ b/cmd/compose
@@ -127,6 +127,10 @@ esac
         echo "DOCKER_TLS_VERIFY not set to 1, skipping certificate generation"
     fi
     
+    # Wait for Nginx to come up before proceeding
+    echo "* Waiting for Nginx to become available"
+    until [[ $(curl -I -s -u ${INITIAL_ADMIN_USER}:${INITIAL_ADMIN_PASSWORD_PLAIN} http://${TARGET_HOST}/|head -n 1|cut -d$' ' -f2) == 200 ]]; do echo "Nginx unavailable, sleeping for 5s"; sleep 5; done
+    
     # Tell the user something useful
     echo
     echo '##########################################################'


### PR DESCRIPTION
Fixes #121 by adding a sleep loop to wait for Nginx to become available.

It appears that sometimes although Docker has done it's part the actual connectivity isn't in place immediately, which might be down to load on the underlying Travis infrastructure. This was proven by connectivity tests either side of a sleep command that showed that after a variable period of time the adop target command would succeed.

Remaining work:

- Run the build ~10 times and see how often it waits for Nginx and is successful each time

Successful builds for evidence:

- https://travis-ci.org/nickdgriffin/adop-docker-compose/builds/149627572 (this PR) - waited 5s for Nginx
- https://travis-ci.org/Accenture/adop-docker-compose/builds/149627576 (this PR) - waited 0s for Nginx
- https://travis-ci.org/nickdgriffin/adop-docker-compose/builds/149627820 - waited 40s for Nginx
- https://travis-ci.org/Accenture/adop-docker-compose/builds/149627822 - waited 20s for Nginx