### PR TITLE
Adding random password generation for ldap admin

### DIFF
--- a/credentials.generate.sh
+++ b/credentials.generate.sh
@@ -80,8 +80,8 @@ else
 	fi
 	sed -i'' -e "s/###INITIAL_ADMIN_PASSWORD_PLAIN###/$INITIAL_ADMIN_PASSWORD_PLAIN/g" platform.secrets.sh
 		
-	# Generate random passwords for Jenkins, Gerrit and SQL and place them in secrets file
-	echo "Generating random passwords for Jenkins, Gerrit and SQL..."
+	# Generate random passwords for Jenkins, Gerrit, SQL, LDAP Admin and place them in secrets file
+	echo "Generating random passwords for Jenkins, Gerrit, SQL and LDAP admin..."
 	PASSWORD_JENKINS=$(createPassword)
 	sed -i'' -e "s/###PASSWORD_JENKINS_PLAIN###/$PASSWORD_JENKINS/g" platform.secrets.sh
 	
@@ -90,6 +90,9 @@ else
 	
 	PASSWORD_SQL=$(createPassword)
 	sed -i'' -e "s/###PASSWORD_SQL_PLAIN###/$PASSWORD_SQL/g" platform.secrets.sh
+
+	PASSWORD_LDAP=$(createPassword)
+	sed -i'' -e "s/###LDAP_PWD###/$PASSWORD_LDAP/g" platform.secrets.sh
 
 fi
 
@@ -111,13 +114,14 @@ fi
 if  [ $INITIAL_ADMIN_PASSWORD_PLAIN == "###INITIAL_ADMIN_PASSWORD_PLAIN###" ] || \
 	[ $PASSWORD_JENKINS == "###PASSWORD_JENKINS_PLAIN###" ] || \
 	[ $PASSWORD_GERRIT == "###PASSWORD_GERRIT_PLAIN###" ] || \
-	[ $PASSWORD_SQL == "###PASSWORD_SQL_PLAIN###" ]; then
+	[ $PASSWORD_SQL == "###PASSWORD_SQL_PLAIN###" ] || \
+	[ $LDAP_PWD == "###LDAP_PWD###" ]; then
 	echo "Your passwords are set to the default tokens provided in the example secrets file, this is not allowed."
 	echo "Delete the platform.secrets.sh file or edit it and then, re-run the credentials.generate.sh script"
 	exit
 fi
 
-# Export the passwords in base64 to be passed in as environment variable for LDAP container
+# Export the passwords in base64 to be passed in as environment variables for LDAP container
 export INITIAL_ADMIN_PASSWORD=$(echo -n $INITIAL_ADMIN_PASSWORD_PLAIN | base64)
 export JENKINS_PWD=$(echo -n $PASSWORD_JENKINS | base64)
 export GERRIT_PWD=$(echo -n $PASSWORD_GERRIT | base64)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ ldap:
   container_name: ldap
   restart: always
   #build: ../images/docker-ldap/
-  image: accenture/adop-ldap:0.1.2
+  image: accenture/adop-ldap:0.1.3
   net: ${CUSTOM_NETWORK_NAME}
   expose:
     - "389"

--- a/env.config.sh
+++ b/env.config.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Globals
-
-export LDAP_PWD="Jpk66g63ZifGYIcShSGM"
 
 # LDAP
 

--- a/platform.secrets.sh.example
+++ b/platform.secrets.sh.example
@@ -18,3 +18,6 @@ export PASSWORD_GERRIT="###PASSWORD_GERRIT_PLAIN###"
 
 # Root password for the Sonar and Gerrit MySQL instances
 export PASSWORD_SQL="###PASSWORD_SQL_PLAIN###"
+
+# Admin password for LDAP
+export LDAP_PWD="###LDAP_PWD###"


### PR DESCRIPTION
- Previously LDAP admin password was hard-coded thus exposing a security vulnerability as anyone could log into LDAP admin and reset passwords/modify users. 
- Repeated the mechanism for random password generation used for other passwords
- Tested in regular bash and git bash