### PR TITLE
Adding version checking of secrets file

### DIFF
--- a/platform.secrets.sh.example
+++ b/platform.secrets.sh.example
@@ -1,5 +1,9 @@
 # Example file to store all the generated secrets for your ADOP stack
 
+# Version ID of the example secrets file, note this needs to be the FULL SHA1 commit ID if you build this file by hand
+# To do this by hand, run the following command: git log -1 --format='%H' HEAD platform.secrets.sh.example
+export VERSION_ID="###VERSION_ID###"
+
 # Username for initial admin user
 export INITIAL_ADMIN_USER="###INITIAL_ADMIN_USER###"
 


### PR DESCRIPTION
- We can now check the version of the example secrets file using commit IDs
- This is in case we make changes to the format so we can validate whether your existing, undeleted secrets file is out of date
- Script will error out in case of a mismatch