### PR TITLE
Selenium Hub and Nodes update to 2.53.0 version, fix #90

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -263,7 +263,7 @@ jenkins-slave:
 selenium-hub:
   container_name: selenium-hub
   restart: always
-  image: selenium/hub:2.46.0
+  image: selenium/hub:2.53.0
   net: ${CUSTOM_NETWORK_NAME}
   expose:
     - "4444"
@@ -271,20 +271,22 @@ selenium-hub:
 selenium-node-chrome:
   container_name: selenium-node-chrome
   restart: always
-  image: selenium/node-chrome:2.46.0
+  image: selenium/node-chrome:2.53.0
   net: ${CUSTOM_NETWORK_NAME}
   environment:
     SE_OPTS: "-nodeConfig /var/selenium-config/config-chrome.json"
+    REMOTE_HOST: "http://selenium-node-chrome:5555"
     HUB_PORT_4444_TCP_ADDR: "selenium-hub"
     HUB_PORT_4444_TCP_PORT: "4444"
 
 selenium-node-firefox:
   container_name: selenium-node-firefox
   restart: always
-  image: selenium/node-firefox:2.46.0
+  image: selenium/node-firefox:2.53.0
   net: ${CUSTOM_NETWORK_NAME}
   environment:
     SE_OPTS: "-nodeConfig /var/selenium-config/config-firefox.json"
+    REMOTE_HOST: "http://selenium-node-firefox:5555"
     HUB_PORT_4444_TCP_ADDR: "selenium-hub"
     HUB_PORT_4444_TCP_PORT: "4444"
 


### PR DESCRIPTION
- Update Selenium Hub and Selenium Nodes Firefox/Chrome to 2.53.0 version of Docker image.
- Fixed #90 , added REMOTE_HOST instruction to make Selenium works on Docker overlay network in ADOP deployed on Docker Swarm.
- FIREFOX_VERSION 47.0.1
- CHROME_DRIVER_VERSION 2.23