### PR TITLE
Update adop-outer-proxy 0.2.1 to fix Amazon ELB in Swarm

### DIFF
--- a/provision/aws/swarm/CF-ADOP-Cluster.json
+++ b/provision/aws/swarm/CF-ADOP-Cluster.json
@@ -1709,7 +1709,7 @@
               "systemctl daemon-reload && systemctl restart docker\n",
               "docker run --restart=\"always\" -p 80:80 -d -e TARGET=",
               { "Fn::GetAtt": [ "ProxyPrivateElasticLoadBalancer", "DNSName" ] },
-              " --name=outer-proxy-nginx -d accenture/adop-outer-proxy:0.2.0 \n"
+              " --name=outer-proxy-nginx -d accenture/adop-outer-proxy:0.2.1 \n"
               ]
             ]
           }


### PR DESCRIPTION
New release of docker image was made:
- "Added "resolver" instruction to support Amazon ELB
" - https://github.com/Accenture/adop-outer-proxy/releases/tag/0.2.1