### PR TITLE
Export TCP port 50000 JNLP to jenkins master host to enable slaves outside of the docker container network to connect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,6 +198,8 @@ jenkins:
   image: accenture/adop-jenkins:0.2.0
   #build: ../images/docker-jenkins/
   net: ${CUSTOM_NETWORK_NAME}
+  ports:
+    - "50000/tcp:50000/tcp"
   expose:
     - "8080"
     - "50000"


### PR DESCRIPTION
As a user I want to be able to use the JNLP slave agent listener listening on Jenkins master TCP port 50000 to connect slaves that are not a part of the docker container network (e.g. windows slaves).