### PR TITLE
Updating nexus image version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -297,7 +297,7 @@ selenium-node-firefox:
 nexus:
   container_name: nexus
   restart: always
-  image:  accenture/adop-nexus:0.1.0
+  image:  accenture/adop-nexus:0.1.3
   net: ${CUSTOM_NETWORK_NAME}
   expose:
     - "8081"


### PR DESCRIPTION
Updating the image version of Nexus to be latest tag, as well as referencing new environment variable which can be set to true to enable debug logging.