### PR TITLE
Adding CLI option to not use logging driver

### DIFF
--- a/cmd/compose
+++ b/cmd/compose
@@ -25,6 +25,7 @@ help() {
     printf "    %-22s   %s\n" "init" "Initialises ADOP"
     printf "    %-22s   %s\n" "init <--without-load>" "Initialises ADOP without loading the platform"
     printf "    %-22s   %s\n" "init <--without-pull>" "Initialises ADOP without pulling images"
+    printf "    %-22s   %s\n" "init <--with-stdout>" "Initialises ADOP with logs being sent to stdout as opposed to specified logging driver"
     printf "    %-22s   %s\n" "up" "docker-compose up for ADOP"
     printf "    %-22s   %s\n" "gen-certs <path>" "Generate client certificates for TLS-enabled Machine and copy to <path> in Jenkins Slave"
     printf "    %-22s   %s\n" "<command>" "Runs 'docker-compose <command>' for ADOP, where <command> is not listed above"
@@ -78,8 +79,8 @@ prep_env() {
     source ${CONF_DIR}/credentials.generate.sh
     source ${CONF_DIR}/env.config.sh
     if [ -f "${CONF_DIR}/env.override.sh" ]; then
-	echo "Using ${CONF_DIR}/env.override.sh to override default values for environment variable."
-	source ${CONF_DIR}/env.override.sh
+        echo "Using ${CONF_DIR}/env.override.sh to override default values for environment variable."
+        source ${CONF_DIR}/env.override.sh
     fi
 }
 
@@ -91,6 +92,9 @@ case "$1" in
         ;;
     --without-load)
         export LOAD="NO"
+        ;;
+    --with-stdout)
+        export LOGS="NO"
         ;;
     *)
 esac
@@ -115,6 +119,17 @@ esac
     create_network
 
     # Run the Docker compose commands
+
+    
+    # Setting Compose File Lists
+    if [ "${LOGS}" = "NO" ]; then
+        ADOPFILEOPTS="-f ${CLI_DIR}/docker-compose.yml -f ${CLI_DIR}/etc/volumes/${VOLUME_DRIVER}/default.yml"
+        echo "* Logs being send to stdout, specified logging driver not being used..."
+    else
+        ADOPFILEOPTS="-f ${CLI_DIR}/docker-compose.yml -f ${CLI_DIR}/etc/volumes/${VOLUME_DRIVER}/default.yml -f ${CLI_DIR}/etc/logging/${LOGGING_DRIVER}/default.yml"
+    fi
+
+    ELKFILEOPTS="-f ${CLI_DIR}/compose/elk.yml"
 
     if [ "${PULL}" = "NO" ]; then
         echo "* Skipping Pulling Docker Images"
@@ -329,9 +344,6 @@ if [ $# -ge 1 ]; then
     shift
 fi
 
-# Setting Compose File Lists
-ADOPFILEOPTS="-f ${CLI_DIR}/docker-compose.yml -f ${CLI_DIR}/etc/volumes/${VOLUME_DRIVER}/default.yml -f ${CLI_DIR}/etc/logging/${LOGGING_DRIVER}/default.yml"
-ELKFILEOPTS="-f ${CLI_DIR}/compose/elk.yml"
 
 case ${SUBCOMMAND_OPT} in
     "cmd_desc"|"help"|"init")


### PR DESCRIPTION
By default logs are always sent to the specified logging driver. Added a CLI option  ```adop compose init --with-stdout``` which enables us to not forward the logs to the specified logging driver, and simply run ```docker logs``` for the required container on the host.