### PR TITLE
Fix for using multiple flags with adop compose init

### DIFF
--- a/cmd/compose
+++ b/cmd/compose
@@ -86,18 +86,27 @@ prep_env() {
 
 init() {
 
-case "$1" in
-    --without-pull)
-        export PULL="NO"
-        ;;
-    --without-load)
-        export LOAD="NO"
-        ;;
-    --with-stdout)
-        export LOGS="NO"
-        ;;
-    *)
-esac
+while [[ $1 ]]; do
+    case "$1" in
+        --without-pull)
+            export PULL="NO"
+            shift
+            ;;
+        --without-load)
+            export LOAD="NO"
+            shift
+            ;;
+        --with-stdout)
+            export LOGS="NO"
+            shift
+            ;;
+        *)
+            echo "Unrecognized option: $1"
+            help
+            exit 1
+            ;;
+    esac
+done
 
     echo ' 
           ###    ########   #######  ########  


### PR DESCRIPTION
Wrapped the case statement at the start of adop compose init() with a while loop so all options are read instead of just the first one.