### PR TITLE
Removing Selenium host mounting

### DIFF
--- a/etc/volumes/local/default.yml
+++ b/etc/volumes/local/default.yml
@@ -59,14 +59,6 @@ jenkins:
     - jenkins_home:/var/jenkins_home 
     - /var/run/docker.sock:/var/run/docker.sock
 
-selenium-node-chrome:
-  volumes:
-    - ./volumes/selenium-config-vol:/var/selenium-config
-
-selenium-node-firefox:
-  volumes:
-    - ./volumes/selenium-config-vol:/var/selenium-config
-
 nexus:
   volumes:
     - nexus_sonatype_work:/sonatype-work


### PR DESCRIPTION
Removing Selenium host mounting. The local directory was removed a long time ago and I'm not sure why this has been left in.