### PR TITLE
Removing ADOP_PLATFORM_MANAGEMENT_VERSION

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,7 +210,6 @@ jenkins:
     - "50000"
   privileged: true
   environment:
-    ADOP_PLATFORM_MANAGEMENT_VERSION: "0.1.1"
     JENKINS_OPTS: "--prefix=/jenkins"
     ROOT_URL: "${PROTO}://${TARGET_HOST}/jenkins/"
     LDAP_SERVER: "${LDAP_SERVER}"


### PR DESCRIPTION
Removing ADOP_PLATFORM_MANAGEMENT_VERSION in preparation for Accenture/adop-platform-management#11.

This is because the existing value is a tag, which won't be supported (see the other PR), and so I'd like to remove this now so it can trickle through and it'll be updated to use the correct value once the other PR has been merged.