### PR TITLE
Added new system variable for cartridge sources

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,7 +200,7 @@ sonar:
 jenkins:
   container_name: jenkins
   restart: always
-  image: accenture/adop-jenkins:0.2.2
+  image: accenture/adop-jenkins:0.2.3
   #build: ../images/docker-jenkins/
   net: ${CUSTOM_NETWORK_NAME}
   ports:
@@ -252,6 +252,7 @@ jenkins:
     DOCKER_HOST: ${DOCKER_HOST}
     DOCKER_CLIENT_CERT_PATH: ${DOCKER_CLIENT_CERT_PATH}
     DOCKER_NETWORK_NAME: ${CUSTOM_NETWORK_NAME}
+    CARTRIDGE_SOURCES: ${CARTRIDGE_SOURCES}
 
 jenkins-slave:
   container_name: jenkins-slave

--- a/env.config.sh
+++ b/env.config.sh
@@ -25,7 +25,7 @@ export GERRIT_MYSQL_DATABASE="gerrit"
 
 # Gerrit
 
-export GERRIT_USER_NAME="Gerrit Code Review" 
+export GERRIT_USER_NAME="Gerrit Code Review"
 export GERRIT_USER_EMAIL="gerrit@adop"
 
 # Gerrit and Jenkins
@@ -42,6 +42,7 @@ export SONAR_MYSQL_DATABASE="sonar"
 export SONAR_ACCOUNT_LOGIN="jenkins"
 export SONAR_DB_LOGIN=${SONAR_MYSQL_USER}
 export SONAR_DB_PASSWORD=${SONAR_MYSQL_PASSWORD}
+export CARTRIDGE_SOURCES="https://raw.githubusercontent.com/Accenture/adop-cartridges/master/cartridges.yml"
 
 # Jenkins Slave
 export SLAVE_EXECUTORS=1


### PR DESCRIPTION
The CARTRIDGE_SOURCES variable has been added so that it propagates to adop-jenkins, where it is used as a Jenkins variable in order for the cartridge loader to have a place to load a list of cartridges from.

Depends on: https://github.com/Accenture/adop-platform-management/pull/32
Depends on: https://github.com/Accenture/adop-jenkins/pull/31

The cartridges list repository should also be added into the official Accenture account: https://github.com/DavideVi/adop-cartridges