### PR TITLE
HTTP GET request to get load_cartridge job to load defaults params.

### DIFF
--- a/cmd/project
+++ b/cmd/project
@@ -117,6 +117,7 @@ load() {
   export PARAMETERS="CARTRIDGE_CLONE_URL=${CARTRIDGE_CLONE_URL}&CARTRIDGE_FOLDER=${CARTRIDGE_FOLDER}&FOLDER_DISPLAY_NAME=${FOLDER_DISPLAY_NAME}&FOLDER_DESCRIPTION=${FOLDER_DESCRIPTION}&ENABLE_CODE_REVIEW=${ENABLE_CODE_REVIEW}"
   echo "Loading the cartridge ..."
   set +e
+  curl -I --max-time 60 -s -X GET -u ${ADOP_CLI_USER}:${ADOP_CLI_PASSWORD} ${JOB_URL}/build?delay=0sec 2>/dev/null | head -1 | cut -d$' ' -f2 | grep 201 >/dev/null
   curl -I --max-time 60 -s -X POST -u ${ADOP_CLI_USER}:${ADOP_CLI_PASSWORD} ${JOB_URL}/buildWithParameters?${PARAMETERS} 2>/dev/null | head -1 | cut -d$' ' -f2 | grep 201 >/dev/null
   CMD_RC=$?
   set -e
@@ -165,9 +166,11 @@ load_collection() {
   # Validate if the ADOP_CLI_URL is a valid url
   load_credentials
   export JOB_URL="${TARGET_HOST}/jenkins/job/${WORKSPACE_NAME}/job/${PROJECT_NAME}/job/Cartridge_Management/job/Load_Cartridge_Collection"
+  export CARTRIDGE_JOB_URL="${TARGET_HOST}/jenkins/job/${WORKSPACE_NAME}/job/${PROJECT_NAME}/job/Cartridge_Management/job/Load_Cartridge"
   export PARAMETERS="COLLECTION_URL=${CARTRIDGE_COLLECTION_URL}"
   echo "Loading the cartridge collection ..."
   set +e
+  curl -I --max-time 60 -s -X GET -u ${ADOP_CLI_USER}:${ADOP_CLI_PASSWORD} ${CARTRIDGE_JOB_URL}/build?delay=0sec 2>/dev/null | head -1 | cut -d$' ' -f2 | grep 201 >/dev/null
   curl -I --max-time 60 -s -X POST -u ${ADOP_CLI_USER}:${ADOP_CLI_PASSWORD} ${JOB_URL}/buildWithParameters?${PARAMETERS} 2>/dev/null | head -1 | cut -d$' ' -f2 | grep 201 >/dev/null
   CMD_RC=$?
   set -e
@@ -218,7 +221,7 @@ create() {
       create_help
       exit 1
   fi
-  
+
   echo ${PROJECT_NAME} ${WORKSPACE_NAME}
   # Validate if the ADOP_CLI_URL is a valid url
   load_credentials
@@ -273,4 +276,3 @@ case ${SUBCOMMAND_OPT} in
         exit 1
         ;;
 esac
-


### PR DESCRIPTION
The SCM provider parameter is an empty string when the Load_Cartridge job is invoked from a Load_Cartridge_Collection when using the ADOP CLI prior to load cartridge being built through the UI. 

This is beacuse;
- the SCM provider default choice list has not been populated
- build parameters that are generated by Scriptler/Groovy scripts are only populated when the Load_Cartridge job "buildWithParameters" has been clicked.

To resolve this prior to running Load_Cartridge a HTTP GET request can be executed to ensure the default parameters are loaded.

To confirm this change behaves as expected check out this PR and run the following CLI commands against a target ADOP. Compare the results with the CLI prior to this PR.

```
./adop workspace -w DOA create; sleep 10
./adop project -p Labs -w DOA create; sleep 10
./adop project -p Labs -w DOA load_collection -c https://raw.githubusercontent.com/Accenture/adop-doa-materials/master/Cartridge_Collections/doa_cartridge_collection.json
```
