### PR TITLE
Expose LDAP container tcp port 389 to host.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ ldap:
   net: ${CUSTOM_NETWORK_NAME}
   expose:
     - "389"
+  ports:
+    - "389/tcp:389/tcp"
   environment:
     INITIAL_ADMIN_USER: ${INITIAL_ADMIN_USER}
     INITIAL_ADMIN_PASSWORD: ${INITIAL_ADMIN_PASSWORD}


### PR DESCRIPTION
As a platform developer,
I want to expose the LDAP tcp port 389 to the host
So that I can consume the LDAP service in applications (OpenVPN etc) that are not in the ADOP Docker network

Signed-off-by: Northard, Robert A <robert.a.northard@accenture.com>