### PR TITLE
Updating GitHub Pages links to HTTPS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please see the contribution documentation: http://accenture.github.io/adop-docker-compose/docs/contributing/
+Please see the contribution documentation: https://accenture.github.io/adop-docker-compose/docs/contributing/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Once you have explored this the next step is to create your own Workspace and Pr
 
 # Quickstart Instructions
 
-These instructions will spin up an instance in a single server in AWS (for evaluation purposes).  Please check the [prerequisites](http://accenture.github.io/adop-docker-compose/docs/prerequisites/).
+These instructions will spin up an instance in a single server in AWS (for evaluation purposes).  Please check the [prerequisites](https://accenture.github.io/adop-docker-compose/docs/prerequisites/).
 
 NB. the instructions will also work in anywhere supported by [Docker Machine](https://docs.docker.com/machine/), just follow the relevant Docker Machine instructions for your target platform and then start at step 3 below and (you can set the AWS_VPC_ID to NA).
 
@@ -196,13 +196,13 @@ Kibana 4 does not provide a configuration property that allow to define the defa
 # User Feedback
 
 ## Documentation
-Documentation can be found [on our GitHub Pages site](http://accenture.github.io/adop-docker-compose).
+Documentation can be found [on our GitHub Pages site](https://accenture.github.io/adop-docker-compose).
 
 ## Issues
 If you have any problems with or questions about this project, please contact us through [Gitter](https://gitter.im/Accenture/ADOP) or a [GitHub issue](https://github.com/Accenture/adop-docker-compose/issues).
 
 ## Contribute
-You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can. You can find more information in our [documentation](http://accenture.github.io/adop-docker-compose/docs/contributing/).
+You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can. You can find more information in our [documentation](https://accenture.github.io/adop-docker-compose/docs/contributing/).
 
 Before you start to code, we recommend discussing your plans through a [GitHub issue](https://github.com/Accenture/adop-docker-compose/issues), especially for more ambitious contributions. This gives other contributors a chance to point you in the right direction, give you feedback on your design, and help you find out if someone else is working on the same thing.
 

--- a/cmd/cartridge
+++ b/cmd/cartridge
@@ -142,8 +142,8 @@ init() {
 
   # Attempt to customise the cartridge template
   if [ ! -d ".git" ]; then
-    echo "WARNING: it doesn't appear that your are running this from the root directory of a git repository.  Therefore unable to pre-populate src/urls.txt in your cartridge.  Please do this manually. See http://accenture.github.io/adop-docker-compose/docs/developing/cartridges/#developing-cartridge-content"
-  else 
+    echo "WARNING: it doesn't appear that your are running this from the root directory of a git repository.  Therefore unable to pre-populate src/urls.txt in your cartridge.  Please do this manually. See https://accenture.github.io/adop-docker-compose/docs/developing/cartridges/#developing-cartridge-content"
+  else
     THIS_URL=`git remote -v | grep push | awk '{print $2}'`
     if [ ! -z "$THIS_URL" ]; then
       # pre-populate the urls.txt with this repo
@@ -165,7 +165,7 @@ init() {
       done
 
     else
-      echo "WARNING: your git repository doesn't have any remotes.  Therefore unable to pre-populate src/urls.txt in your cartridge.  Please do this manually. See http://accenture.github.io/adop-docker-compose/docs/developing/cartridges/#developing-cartridge-content"
+      echo "WARNING: your git repository doesn't have any remotes.  Therefore unable to pre-populate src/urls.txt in your cartridge.  Please do this manually. See https://accenture.github.io/adop-docker-compose/docs/developing/cartridges/#developing-cartridge-content"
     fi
   fi
 
@@ -173,7 +173,7 @@ init() {
   # We don't want the cartridge dir to be it's own git repo
   rm -rf ${SUBDIR}/.git
 
-  printf "\nCartridge skeleton successfully created.\n\nYou can now load it into an ADOP instance: http://accenture.github.io/adop-docker-compose/docs/developing/cartridges/#testing-the-cartridge\n"
+  printf "\nCartridge skeleton successfully created.\n\nYou can now load it into an ADOP instance: https://accenture.github.io/adop-docker-compose/docs/developing/cartridges/#testing-the-cartridge\n"
 
 }
 


### PR DESCRIPTION
I've updated the HTTP links to HTTPS, because who doesn't like a bit of encryption on their HTTP traffic?

I also noticed that there's a setting on the repository to enforce it so I've set that as well, but I think it can't hurt to update the URLs anyway just to make a point.