### PR TITLE
Changing Suggested Instance to r4.xlarge from m4.xlarge

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The platform is designed to run on any container platform.
 
 - Create a Docker Engine in AWS (replace the placeholders and their <> markers): 
 ```sh
-docker-machine create --driver amazonec2 --amazonec2-access-key <YOUR_ACCESS_KEY> --amazonec2-secret-key <YOUR_SECRET_KEY> --amazonec2-vpc-id <YOUR_VPC_ID> --amazonec2-instance-type m4.xlarge --amazonec2-region <YOUR_AWS_REGION, e.g. eu-west-1> <YOUR_MACHINE_NAME>
+docker-machine create --driver amazonec2 --amazonec2-access-key <YOUR_ACCESS_KEY> --amazonec2-secret-key <YOUR_SECRET_KEY> --amazonec2-vpc-id <YOUR_VPC_ID> --amazonec2-instance-type r4.xlarge --amazonec2-region <YOUR_AWS_REGION, e.g. eu-west-1> <YOUR_MACHINE_NAME>
 ```
 
 - Update the docker-machine security group to permit inbound http traffic on port 80 (from the machine(s) from which you want to have access only), also UDP on 25826 and 12201 from 127.0.0.1/32

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -126,7 +126,7 @@ provision_aws() {
     fi
     
     if [ -z ${AWS_DOCKER_MACHINE_SIZE} ]; then
-    	export AWS_DOCKER_MACHINE_SIZE="m4.xlarge"
+    	export AWS_DOCKER_MACHINE_SIZE="r4.xlarge"
     fi
 
     # Create a file with AWS parameters


### PR DESCRIPTION
In practice, we were seeing ADOP stack crashes under moderate use. Each time, available RAM was low. Once, during a build that deployed additional containers, we _witnessed_, in real time, the stack crash due to ram.

We have been running the stack with this configuration for 2 weeks now, and it is much more stable. The incremental cost is approx $40/month (assuming no preferential pricing). 