### PR TITLE
Adding evaluation mode disclaimer and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Once you have explored this the next step is to create your own Workspace and Pr
 
 # Quickstart Instructions
 
-These instructions will spin up an instance in a single server in AWS (for evaluation purposes).  Please check the [prerequisites](https://accenture.github.io/adop-docker-compose/docs/prerequisites/).
+These instructions will spin up an instance in a single server in AWS ([for **_evaluation_** purposes](https://accenture.github.io/adop-docker-compose/docs/evaluation-mode)).  Please check the [prerequisites](https://accenture.github.io/adop-docker-compose/docs/prerequisites/).
 
 NB. the instructions will also work in anywhere supported by [Docker Machine](https://docs.docker.com/machine/), just follow the relevant Docker Machine instructions for your target platform and then start at step 3 below and (you can set the AWS_VPC_ID to NA).
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -10,6 +10,20 @@ echo '
    ##     ## ########   #######  ##        
 '
 
+echo '
+*****************************************************
+*                  EVALUATION MODE                  *
+*****************************************************
+* Quickstart is designed to get you up and running  *
+* with the DevOps Platform as quickly as possible.  *
+* As such it is not a "production" ready deployment *
+* and therefore we brand it as "evaluation mode".   *
+* In using quickstart you are acknowledging this,   *
+* along with the lack of proper security, backups,  *
+* patching, and other operational considerations.   *
+*****************************************************
+'
+
 usage(){
    cat <<END_USAGE
 

--- a/site/_data/docs.yml
+++ b/site/_data/docs.yml
@@ -3,6 +3,7 @@
   - home
   - prerequisites
   - quickstart
+  - evaluation-mode
   - recommended-reading
 
 - title: Architecture

--- a/site/_docs/evaluation-mode.md
+++ b/site/_docs/evaluation-mode.md
@@ -1,0 +1,21 @@
+---
+layout: docs
+title: Evaluation Mode 
+permalink: /docs/evaluation-mode/
+---
+
+Evaluation mode is intended to be the quickest path to running the DevOps Platform, and is ideal for the following use cases:
+
+* Trialing the DevOps Platform and the tools within it
+* Proof of concepts/demos
+* Local development environment for the DevOps Platform
+
+It is not suitable for, nor intended to be used, in production as there are numerous operational items that need to be taken care of by the deployer:
+
+* Security
+    * Quickstart uses Docker Machine to launch a VM that is public facing and leaves the Docker Engine port exposed
+* Backups
+    * Data is stored directly on the host that is created which means that when it is terminated the data will be lost
+* Patching
+    * Once the DevOps Platform has been deployed manual intervention will be required to apply patches
+

--- a/site/_docs/quickstart.md
+++ b/site/_docs/quickstart.md
@@ -4,7 +4,7 @@ title: Quickstart
 permalink: /docs/quickstart/
 ---
 
-These instructions will spin up an instance in a single server in AWS (for evaluation purposes). Please check the [prerequisites](/adop-docker-compose/docs/prerequisites/).
+These instructions will spin up an instance in a single server in AWS ([for **_evaluation_** purposes](/adop-docker-compose/docs/evaluation-mode)). Please check the [prerequisites](/adop-docker-compose/docs/prerequisites/).
 
 NB. the instructions will also work in anywhere supported by [Docker Machine](https://docs.docker.com/machine/), just follow the relevant Docker Machine instructions for your target platform and then start at step 3 below and (you can set the VPC_ID to NA).
 


### PR DESCRIPTION
This PR adds a disclaimer for evaluation mode to quickstart.sh along with some documentation updates to include "officially" talking about it.