### PR TITLE
Adding -h to print usage, just to avoid the error message

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -164,7 +164,7 @@ provision_aws() {
     fi
 }
 
-while getopts "t:m:a:s:c:z:r:u:p:" opt; do
+while getopts "t:m:a:s:c:z:r:u:p:h" opt; do
   case ${opt} in
     t)
       export MACHINE_TYPE=${OPTARG}
@@ -193,6 +193,10 @@ while getopts "t:m:a:s:c:z:r:u:p:" opt; do
     p)
       export INITIAL_ADMIN_PASSWORD_PLAIN=${OPTARG}
       ;;      
+    h)
+      usage
+      exit
+      ;;
     *)
       echo "Invalid parameter(s) or option(s)."
       usage


### PR DESCRIPTION
Previously "./quickstarh.sh -h" would print an error about it being an invalid parameter and print the usage, now it'll just print the usage.

Also means in future it could have an expanded help if necessary.