### PR TITLE
Changed port instruction format in docker-compose file according to the latest format

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ ldap:
   expose:
     - "389"
   ports:
-    - "389/tcp:389/tcp"
+    - "389:389/tcp"
   environment:
     INITIAL_ADMIN_USER: ${INITIAL_ADMIN_USER}
     INITIAL_ADMIN_PASSWORD: ${INITIAL_ADMIN_PASSWORD}
@@ -206,7 +206,7 @@ jenkins:
   #build: ../images/docker-jenkins/
   net: ${CUSTOM_NETWORK_NAME}
   ports:
-    - "50000/tcp:50000/tcp"
+    - "50000:50000/tcp"
   expose:
     - "8080"
     - "50000"


### PR DESCRIPTION
Hi team,

This is an important change that is blocking adop installation using existing docker-compose.yml on a server or Swarm API where docker-compose is v1.13+

Can it be merged to master?

@nickdgriffin @SachinKSingh28 