### PR TITLE
Bumping Jenkins image version to 0.2.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,7 +204,7 @@ sonar:
 jenkins:
   container_name: jenkins
   restart: always
-  image: accenture/adop-jenkins:0.2.6
+  image: accenture/adop-jenkins:0.2.7
   #build: ../images/docker-jenkins/
   net: ${CUSTOM_NETWORK_NAME}
   ports:


### PR DESCRIPTION
Bumping Jenkins image version to 0.2.7, in support of Accenture/adop-platform-management#11