### PR TITLE
Set env variable for jenkins user.

### DIFF
--- a/cmd/compose
+++ b/cmd/compose
@@ -153,7 +153,7 @@ done
     # Wait for Jenkins and Gerrit to come up before proceeding
     echo "* Waiting for the Platform to become available - this can take a few minutes"
     TOOL_SLEEP_TIME=30
-    until [[ $(docker exec jenkins curl -I -s jenkins:${PASSWORD_JENKINS}@localhost:8080/jenkins/|head -n 1|cut -d$' ' -f2) == 200 ]]; do pretty_sleep ${TOOL_SLEEP_TIME} Jenkins; done
+    until [[ $(docker exec jenkins curl -I -s ${USERNAME_JENKINS}:${PASSWORD_JENKINS}@localhost:8080/jenkins/|head -n 1|cut -d$' ' -f2) == 200 ]]; do pretty_sleep ${TOOL_SLEEP_TIME} Jenkins; done
     until [[ $(docker exec gerrit curl -I -s gerrit:${PASSWORD_GERRIT}@localhost:8080/gerrit/|head -n 1|cut -d$' ' -f2) == 200 ]]; do pretty_sleep ${TOOL_SLEEP_TIME} Gerrit; done
     
     # Trigger Load_Platform in Jenkins
@@ -161,7 +161,7 @@ done
         echo "* Skipping Loading the Platform"
     else
         echo "* Loading the Platform"
-        docker exec jenkins curl -s -X POST jenkins:${PASSWORD_JENKINS}@localhost:8080/jenkins/job/Load_Platform/buildWithParameters --data token=gAsuE35s
+        docker exec jenkins curl -s -X POST ${USERNAME_JENKINS}:${PASSWORD_JENKINS}@localhost:8080/jenkins/job/Load_Platform/buildWithParameters --data token=gAsuE35s
     fi
 
     # Generate and copy the certificates to jenkins slave if TLS is enabled

--- a/env.config.sh
+++ b/env.config.sh
@@ -39,6 +39,7 @@ export SONAR_MYSQL_DATABASE="sonar"
 
 # Jenkins
 
+export USERNAME_JENKINS="jenkins"
 export SONAR_ACCOUNT_LOGIN="jenkins"
 export SONAR_DB_LOGIN=${SONAR_MYSQL_USER}
 export SONAR_DB_PASSWORD=${SONAR_MYSQL_PASSWORD}


### PR DESCRIPTION
In compose cmd file there is a command which checks if Jenkins is up and running and later it triggers Load_Platform job. At the moment Jenkins user is hardcoded, when we use external LDAP probably it will fail because that user doesn't exist there. To avoid that i made env variable "USERNAME_JENKINS" in this way we can set user what we need. 