### PR TITLE
Bumping Nexus image version to 0.1.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -305,7 +305,7 @@ selenium-node-firefox:
 nexus:
   container_name: nexus
   restart: always
-  image:  accenture/adop-nexus:0.1.3
+  image:  accenture/adop-nexus:0.1.4
   net: ${CUSTOM_NETWORK_NAME}
   expose:
     - "8081"


### PR DESCRIPTION
Bumping Nexus image version to 0.1.4, bringing Nexus up to version 2.14.5 in preparation for upgrading to Nexus 3.7.1.