### PR TITLE
Update quickstart.md

### DIFF
--- a/site/_docs/quickstart.md
+++ b/site/_docs/quickstart.md
@@ -46,6 +46,12 @@ NB. the instructions will also work in anywhere supported by [Docker Machine](ht
 
             ```./quickstart.sh -t aws -m adop1 -a AAA -s BBB -c vpc-123abc -r eu-west-1 -u user.name -p userPassword -z c```
 
+        -N.B. If you see a recurrent message saying "Nginx is unavailable..." check the Security Group Settings on your VPC to confirm that it has port 80 open.    
+        - Go to your VPC settings in AWS and navigate to Security Groups using the left menu bar
+        - If there is more than one Security Group setup, highlight the one with group name "docker-machine"
+        - beneath this, open the "inbound rules" tab and if there is not one already, create a new entry for port 80 with source = "0.0.0.0/0", and hit save. 
+
+
 1. If all goes well you will see the following output and you can view the DevOps Platform in your browser using the link that accompanies this output:
 
     ```SUCCESS, your new ADOP instance is ready!```

--- a/site/_docs/quickstart.md
+++ b/site/_docs/quickstart.md
@@ -42,14 +42,16 @@ NB. the instructions will also work in anywhere supported by [Docker Machine](ht
 
         ```./quickstart.sh -t aws -m adop1 -a AAA -s BBB -c vpc-123abc -r eu-west-1 -u user.name -p userPassword```
 
-        - N.B. If you see an error saying that docker-machine cannot find an associated subnet in a zone, go back to the VPC Dashboard on AWS and check the availablity zone for the subnet you've created. Then rerun the startup script and use the -z option to specify the zone for your subnet, e.g. for a zone of eu-west-1c the above command becomes:
+
+        - Possible issues:
+          - If you see an error saying that docker-machine cannot find an associated subnet in a zone, go back to the VPC Dashboard on AWS and check the availablity zone for the subnet you've created. Then rerun the startup script and use the -z option to specify the zone for your subnet, e.g. for a zone of eu-west-1c the above command becomes:
 
             ```./quickstart.sh -t aws -m adop1 -a AAA -s BBB -c vpc-123abc -r eu-west-1 -u user.name -p userPassword -z c```
 
-        -N.B. If you see a recurrent message saying "Nginx is unavailable..." check the Security Group Settings on your VPC to confirm that it has port 80 open.    
-        - Go to your VPC settings in AWS and navigate to Security Groups using the left menu bar
-        - If there is more than one Security Group setup, highlight the one with group name "docker-machine"
-        - beneath this, open the "inbound rules" tab and if there is not one already, create a new entry for port 80 with source = "0.0.0.0/0", and hit save. 
+          - If you see the message "Nginx is unavailable..." more than 10 times, check you have network access on port 80 to the VM created by docker-machine.  For example in AWS check the Security Group Settings:   
+            - Go to your VPC settings in AWS and navigate to Security Groups using the left menu bar
+            - Look for the security group named "docker-machine"
+            - beneath this, open the "inbound rules" tab and if there is not one already, create a new entry for port 80 with source = "0.0.0.0/0", and hit save. 
 
 
 1. If all goes well you will see the following output and you can view the DevOps Platform in your browser using the link that accompanies this output:


### PR DESCRIPTION
Added a check for troubleshooting "Nginx Unavailable" message. I had used the AWS VPC wizard to setup a VPC and security group, but the "docker-machine" security group did not have port 80 opened as part of that setup. This edit includes a check for that, in the event that an Nginx Unavailable message is observed.