### PR TITLE
Lock DOA to a specific version of platform management

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,7 +202,7 @@ sonar:
 jenkins:
   container_name: jenkins
   restart: always
-  image: accenture/adop-jenkins:0.2.6
+  image: accenture/adop-jenkins:0.2.7
   #build: ../images/docker-jenkins/
   net: ${CUSTOM_NETWORK_NAME}
   ports:
@@ -256,6 +256,7 @@ jenkins:
     DOCKER_CLIENT_CERT_PATH: ${DOCKER_CLIENT_CERT_PATH}
     DOCKER_NETWORK_NAME: ${CUSTOM_NETWORK_NAME}
     CARTRIDGE_SOURCES: ${CARTRIDGE_SOURCES}
+    ADOP_PLATFORM_MANAGEMENT_VERSION: "53db75040b44fb94a1ce2d300944e33912c62dfa"
 
 jenkins-slave:
   container_name: jenkins-slave


### PR DESCRIPTION
This commit is to lock DOA ADOP Jenkins to a set version of platform management to unblock https://github.com/Accenture/adop-platform-management/pull/53